### PR TITLE
feat(smb): SMB2 Handle Lease (Phase A-D) + Compound Create+SetInfo+Close

### DIFF
--- a/crates/smb-msg/src/create.rs
+++ b/crates/smb-msg/src/create.rs
@@ -585,6 +585,7 @@ pub struct TimewarpToken {
 ///
 /// Reference: MS-SMB2 2.2.13.2.8, 2.2.13.2.10, 2.2.14.2.10, 2.2.14.2.11
 #[smb_message_binrw]
+#[derive(Clone)]
 pub enum RequestLease {
     RqLsReqv1(RequestLeaseV1),
     RqLsReqv2(RequestLeaseV2),
@@ -595,6 +596,7 @@ pub enum RequestLease {
 ///
 /// Reference: MS-SMB2 2.2.13.2.8, 2.2.14.2.10
 #[smb_message_binrw]
+#[derive(Clone)]
 pub struct RequestLeaseV1 {
     /// Client-generated key that identifies the owner of the lease
     pub lease_key: u128,
@@ -613,6 +615,7 @@ pub struct RequestLeaseV1 {
 ///
 /// Reference: MS-SMB2 2.2.13.2.10, 2.2.14.2.11
 #[smb_message_binrw]
+#[derive(Clone)]
 pub struct RequestLeaseV2 {
     /// Client-generated key that identifies the owner of the lease
     pub lease_key: u128,

--- a/crates/smb-msg/src/oplock.rs
+++ b/crates/smb-msg/src/oplock.rs
@@ -69,6 +69,12 @@ pub enum OplockLevel {
     II = 1,
     /// Exclusive oplock is available.
     Exclusive = 2,
+    /// Lease semantics are in effect for this open. Used in
+    /// `CreateRequest::requested_oplock_level` to signal "I'm sending an
+    /// `RqLs` create context; treat this as a lease request rather than an
+    /// oplock". Per MS-SMB2 2.2.13, the server only honors the `RqLs`
+    /// context when this value is set.
+    Lease = 0xFF,
 }
 
 /// Lease state bitfield representing different types of caching permissions.

--- a/crates/smb-msg/src/oplock.rs
+++ b/crates/smb-msg/src/oplock.rs
@@ -34,15 +34,15 @@ pub struct OplockBreakMsg {
 pub struct LeaseBreakNotify {
     /// A 16-bit unsigned integer indicating a lease state change by the server.
     /// Only valid for SMB 3.x dialect family. For SMB 2.1, this field is reserved.
-    new_epoch: u16,
+    pub new_epoch: u16,
     /// Flag indicating whether a Lease Break Acknowledgment is required.
-    ack_required: u32,
+    pub ack_required: u32,
     /// The client-generated key that identifies the owner of the lease.
-    lease_key: Guid,
+    pub lease_key: Guid,
     /// The current lease state of the open.
-    current_lease_state: LeaseState,
+    pub current_lease_state: LeaseState,
     /// The new lease state for the open.
-    new_lease_state: LeaseState,
+    pub new_lease_state: LeaseState,
     #[bw(calc = 0)]
     #[br(assert(break_reason == 0))]
     #[br(temp)]
@@ -117,10 +117,10 @@ pub struct LeaseBreakAckResponse {
     reserved: u32,
 
     /// The client-generated key that identifies the owner of the lease.
-    lease_key: Guid,
+    pub lease_key: Guid,
     /// The lease state. For acknowledgments, this must be a subset of the lease state
     /// granted by the server. For responses, this is the requested lease state.
-    lease_state: LeaseState,
+    pub lease_state: LeaseState,
 
     /// Lease duration (reserved)
     reserved: u64,

--- a/crates/smb/src/client/config.rs
+++ b/crates/smb/src/client/config.rs
@@ -1,4 +1,5 @@
 use smb_dtyp::Guid;
+use smb_msg::LeaseState;
 
 use crate::ConnectionConfig;
 
@@ -18,6 +19,34 @@ pub struct ClientConfig {
 
     pub client_guid: Guid,
 
+    /// Default lease state to request on every `create_file` call that
+    /// doesn't already carry a `FileCreateArgs::lease_request`. `None`
+    /// (default) keeps the legacy "no lease" behavior on a per-call
+    /// basis; setting `Some(LeaseState::new().with_read_caching(true).with_handle_caching(true))`
+    /// makes the client opportunistically request a HandleCaching lease
+    /// for every open so the per-connection lease cache (Phase C) can
+    /// dedupe subsequent opens against the same path.
+    ///
+    /// The lease key for each path is derived deterministically from
+    /// the [`crate::UncPath`] string and the client's `lease_key_salt`,
+    /// so:
+    ///   * within one Client, repeat opens of the same path use the
+    ///     same lease key — the server reuses the lease,
+    ///   * across two Client instances on the same machine, the salt
+    ///     differs so lease keys differ — the server treats them as
+    ///     two independent clients, no cross-talk.
+    ///
+    /// Servers without leasing capability silently ignore the request
+    /// context, so this is safe to enable by default on capable clients.
+    pub default_lease_state: Option<LeaseState>,
+
+    /// Random 64-bit salt mixed into every auto-generated lease key
+    /// (see [`Self::default_lease_state`]). Initialized to a fresh
+    /// random value on `Default::default()`. Two Client instances see
+    /// different salts so they don't accidentally share lease state on
+    /// the server side.
+    pub lease_key_salt: u64,
+
     #[cfg(feature = "rdma")]
     pub rdma_type: Option<crate::transport::RdmaType>,
 }
@@ -28,6 +57,8 @@ impl Default for ClientConfig {
             dfs: true,
             connection: ConnectionConfig::default(),
             client_guid: Guid::generate(),
+            default_lease_state: None,
+            lease_key_salt: rand::random(),
             #[cfg(feature = "rdma")]
             rdma_type: None,
         }

--- a/crates/smb/src/client/smb_client.rs
+++ b/crates/smb/src/client/smb_client.rs
@@ -514,6 +514,27 @@ impl Client {
         self._with_tree(path, |tree| Ok(tree.session.clone())).await
     }
 
+    /// Subscribe to lease-break notifications for the connection to `server`.
+    ///
+    /// Returns a [`tokio::sync::broadcast::Receiver`] that yields one
+    /// [`crate::LeaseBreakEvent`] per `LeaseBreakNotify` the server sends on
+    /// this connection. The connection task has already replied with a
+    /// `LeaseBreakAck` by the time the event is published, so receivers
+    /// only need to handle the *consequence* of the break (typically:
+    /// drop the cached `FileId` keyed by `lease_key` and force the next
+    /// open to re-issue Create on the wire).
+    ///
+    /// Errors: returns the same set as [`Client::get_connection`]; the
+    /// caller must have already established the connection.
+    #[cfg(feature = "async")]
+    pub async fn subscribe_lease_breaks(
+        &self,
+        server: &str,
+    ) -> crate::Result<tokio::sync::broadcast::Receiver<crate::LeaseBreakEvent>> {
+        let conn = self.get_connection(server).await?;
+        Ok(conn.subscribe_lease_breaks())
+    }
+
     /// Returns a map of channel IDs to their corresponding connections for the specified session,
     pub async fn get_channels(
         &self,

--- a/crates/smb/src/client/smb_client.rs
+++ b/crates/smb/src/client/smb_client.rs
@@ -5,8 +5,8 @@ use maybe_async::maybe_async;
 use smb_fscc::{ChainedItemList, FileBasicInformation, SetFileInfo, SetFileInfoClass};
 use smb_msg::{
     AdditionalInfo, CloseRequest, CreateRequest, FileId, ImpersonationLevel, NetworkInterfaceInfo,
-    OplockLevel, RawSetInfoData, ReferralEntry, ReferralEntryValue, SetInfoClass, SetInfoData,
-    SetInfoRequest, ShareAccessFlags, Status,
+    OplockLevel, RawSetInfoData, ReferralEntry, ReferralEntryValue, RequestContent, SetInfoClass,
+    SetInfoData, SetInfoRequest, ShareAccessFlags, Status,
 };
 use smb_rpc::interface::{LsaRpc, ShareInfo1, SrvSvc, TranslatedName};
 use smb_transport::TransportConfig;
@@ -757,61 +757,64 @@ impl Client {
         let conn = self.get_connection(path.server()).await?;
         let rel = path.path().unwrap_or("");
 
-        // --- Member 1: Create (Open) ---
-        // No lease context; we want immediate Close, not deferred. No DFS
-        // operations on this path — update_metadata is always against
-        // already-resolved paths under a connected share.
-        let create = CreateRequest {
-            requested_oplock_level: OplockLevel::None,
-            impersonation_level: ImpersonationLevel::Impersonation,
-            desired_access: smb_fscc::FileAccessMask::new().with_file_write_attributes(true),
-            file_attributes: smb_fscc::FileAttributes::new(),
-            share_access: ShareAccessFlags::new()
-                .with_read(true)
-                .with_write(true)
-                .with_delete(true),
-            create_disposition: smb_msg::CreateDisposition::Open,
-            create_options: smb_msg::CreateOptions::new(),
-            name: rel.into(),
-            contexts: ChainedItemList::default(),
+        // Helper: fill in the per-member header fields (tree_id, session_id,
+        // signed flag, related_operations) that the three members of this
+        // chain otherwise duplicate. `related = false` is the start of the
+        // chain (Create); `related = true` for the SetInfo and Close that
+        // depend on Create's returned FileId.
+        let make_member = |req: RequestContent, related: bool| {
+            let mut m = OutgoingMessage::new(req);
+            m.message.header.tree_id = Some(tree_id);
+            m.message.header.session_id = session_id;
+            m.message.header.flags.set_signed(signed);
+            if related {
+                m.message.header.flags.set_related_operations(true);
+            }
+            m
         };
-        let mut create_msg = OutgoingMessage::new(create.into());
-        create_msg.message.header.tree_id = Some(tree_id);
-        create_msg.message.header.session_id = session_id;
-        create_msg.message.header.flags.set_signed(signed);
 
-        // --- Member 2: SetInfo(FileBasicInformation) on the previous handle ---
-        // file_id = FULL + related_operations = true makes the server
-        // substitute Create's returned FileId here.
-        let setinfo = SetInfoRequest {
-            info_class: SetInfoClass::File(SetFileInfoClass::BasicInformation),
-            additional_information: AdditionalInfo::new(),
-            file_id: FileId::FULL,
-            data: SetInfoData::File(RawSetInfoData::from(SetFileInfo::BasicInformation(basic))),
-        };
-        let mut setinfo_msg = OutgoingMessage::new(setinfo.into());
-        setinfo_msg.message.header.tree_id = Some(tree_id);
-        setinfo_msg.message.header.session_id = session_id;
-        setinfo_msg.message.header.flags.set_signed(signed);
-        setinfo_msg
-            .message
-            .header
-            .flags
-            .set_related_operations(true);
+        // Member 1: Create with Open disposition. No lease context — we
+        // want an immediate Close, not deferred. No DFS — update_metadata
+        // is always against already-resolved paths under a connected share.
+        let create_msg = make_member(
+            CreateRequest {
+                requested_oplock_level: OplockLevel::None,
+                impersonation_level: ImpersonationLevel::Impersonation,
+                desired_access: smb_fscc::FileAccessMask::new().with_file_write_attributes(true),
+                file_attributes: smb_fscc::FileAttributes::new(),
+                share_access: ShareAccessFlags::new()
+                    .with_read(true)
+                    .with_write(true)
+                    .with_delete(true),
+                create_disposition: smb_msg::CreateDisposition::Open,
+                create_options: smb_msg::CreateOptions::new(),
+                name: rel.into(),
+                contexts: ChainedItemList::default(),
+            }
+            .into(),
+            false,
+        );
 
-        // --- Member 3: Close on the same chained handle ---
-        let close = CloseRequest {
-            file_id: FileId::FULL,
-        };
-        let mut close_msg = OutgoingMessage::new(close.into());
-        close_msg.message.header.tree_id = Some(tree_id);
-        close_msg.message.header.session_id = session_id;
-        close_msg.message.header.flags.set_signed(signed);
-        close_msg
-            .message
-            .header
-            .flags
-            .set_related_operations(true);
+        // Members 2 & 3: SetInfo + Close with FileId::FULL and
+        // related_operations=true, so the server substitutes Create's
+        // returned FileId here per MS-SMB2 3.3.5.2.7.2.
+        let setinfo_msg = make_member(
+            SetInfoRequest {
+                info_class: SetInfoClass::File(SetFileInfoClass::BasicInformation),
+                additional_information: AdditionalInfo::new(),
+                file_id: FileId::FULL,
+                data: SetInfoData::File(RawSetInfoData::from(SetFileInfo::BasicInformation(basic))),
+            }
+            .into(),
+            true,
+        );
+        let close_msg = make_member(
+            CloseRequest {
+                file_id: FileId::FULL,
+            }
+            .into(),
+            true,
+        );
 
         let responses = conn
             .send_compound(vec![create_msg, setinfo_msg, close_msg])

--- a/crates/smb/src/client/smb_client.rs
+++ b/crates/smb/src/client/smb_client.rs
@@ -371,27 +371,29 @@ impl Client {
         let rel = path.path().unwrap_or("").to_string();
 
         // Phase C.3 — cache-hit short-circuit. When the caller asked for a
-        // lease, check the per-connection lease_table first; if there's a
-        // live, non-tombstoned slot with a compatible access mask and the
-        // disposition is `Open`, materialize a fresh Resource from the
-        // slot without touching the wire. This is the actual RT-saving
-        // path that the rest of Phase C is built around.
+        // lease, look up the per-connection `lease_table`; the lookup and
+        // refcount bump happen atomically under the table lock via
+        // `try_acquire_lease`, which serializes us against concurrent
+        // `evict_lease` / `flush_idle_leases` operations so we never
+        // hand out a FileId the evicter has already closed on the wire.
         if args.lease_request.is_some() {
             if let Ok(conn) = self.get_connection(path.server()).await {
-                if let Ok(Some(slot)) = conn.peek_lease_slot(&rel).await {
-                    let wants_dir = args.options.directory_file();
-                    if slot.try_acquire_for_reuse(
+                let wants_dir = args.options.directory_file();
+                if let Ok(Some(slot)) = conn
+                    .try_acquire_lease(
+                        &rel,
                         args.desired_access,
                         args.disposition,
                         wants_dir,
-                    ) {
-                        tracing::debug!(
-                            path = %rel,
-                            file_id = ?slot.file_id,
-                            "Lease cache hit; reusing FileId without Create RT",
-                        );
-                        return Ok(Resource::reuse_from_slot(slot));
-                    }
+                    )
+                    .await
+                {
+                    tracing::debug!(
+                        path = %rel,
+                        file_id = ?slot.file_id,
+                        "Lease cache hit; reusing FileId without Create RT",
+                    );
+                    return Ok(Resource::reuse_from_slot(slot));
                 }
             }
         }
@@ -596,6 +598,92 @@ impl Client {
     ) -> crate::Result<tokio::sync::broadcast::Receiver<crate::LeaseBreakEvent>> {
         let conn = self.get_connection(server).await?;
         Ok(conn.subscribe_lease_breaks())
+    }
+
+    /// Phase C.5: explicit lease eviction for a single path. Tombstones
+    /// the cached slot, removes it from the per-connection table, and
+    /// sends the wire `Close` against the cached `FileId` when this
+    /// caller owns it (no live handles remained at eviction time).
+    ///
+    /// Callers must invoke this *before* destructive operations on the
+    /// path — `delete_file`, `rename`, anything that would invalidate
+    /// the cached FileId server-side — so that subsequent opens don't
+    /// hit a stale entry that the server has already dropped.
+    ///
+    /// Returns `true` when a slot was found and removed, `false` when
+    /// the path had no cached lease (idempotent / safe to call
+    /// preemptively).
+    ///
+    /// The wire `Close` is fire-and-best-effort: failures are logged
+    /// but don't propagate, since the slot is already gone from our
+    /// cache and the path may already be inaccessible (e.g. the
+    /// session lost reconnect, the share dropped).
+    pub async fn evict_lease(&self, path: &UncPath) -> crate::Result<bool> {
+        let rel = path.path().unwrap_or("").to_string();
+        let conn = self.get_connection(path.server()).await?;
+        let Some(eviction) = conn.take_lease_for_evict(&rel).await? else {
+            return Ok(false);
+        };
+        Self::flush_eviction(&path.to_string(), eviction).await;
+        Ok(true)
+    }
+
+    /// Phase C.5: idle-sweep across the connection identified by
+    /// `server`. Tombstones and removes any slot whose `last_used` is
+    /// older than `older_than`; sends the wire `Close` for the ones
+    /// whose refcount was zero at sweep time. Slots with live handles
+    /// stay tombstoned and rely on each handle's deferred-close path.
+    ///
+    /// Returns the number of slots that were tombstoned. A return of
+    /// `0` is normal when no slot has aged past the threshold.
+    pub async fn flush_idle_leases(
+        &self,
+        server: &str,
+        older_than: std::time::Duration,
+    ) -> crate::Result<usize> {
+        let conn = self.get_connection(server).await?;
+        let evictions = conn.sweep_idle_leases(older_than).await?;
+        let count = evictions.len();
+        for eviction in evictions {
+            let label = format!("\\\\{server}\\{}", eviction.slot.path);
+            Self::flush_eviction(&label, eviction).await;
+        }
+        Ok(count)
+    }
+
+    /// Send the wire `Close` for an eviction that owes one. Failures are
+    /// logged at WARN — by the time we reach this point the slot is
+    /// already removed from the cache, so a failed Close just leaks a
+    /// server-side FileId that the session-disconnect will collect.
+    async fn flush_eviction(label: &str, eviction: crate::connection::LeaseEviction) {
+        if !eviction.needs_wire_close {
+            tracing::debug!(
+                path = label,
+                "Eviction handed off to live holder's release_one",
+            );
+            return;
+        }
+        let file_id = eviction.slot.file_id;
+        let handler = eviction.slot.proto.handler.clone();
+        if file_id == smb_msg::FileId::EMPTY {
+            return;
+        }
+        if let Err(e) = crate::resource::ResourceHandle::send_close_external(file_id, &handler)
+            .await
+        {
+            tracing::warn!(
+                path = label,
+                file_id = ?file_id,
+                error = ?e,
+                "Eviction wire Close failed (FileId leaked until session end)",
+            );
+        } else {
+            tracing::debug!(
+                path = label,
+                file_id = ?file_id,
+                "Eviction wire Close sent",
+            );
+        }
     }
 
     /// Returns a map of channel IDs to their corresponding connections for the specified session,

--- a/crates/smb/src/client/smb_client.rs
+++ b/crates/smb/src/client/smb_client.rs
@@ -1,7 +1,13 @@
 use crate::ConnectionConfig;
+use crate::msg_handler::OutgoingMessage;
 use crate::{Connection, Error, FileCreateArgs, Pipe, Resource, Session, Tree, sync_helpers::*};
 use maybe_async::maybe_async;
-use smb_msg::{NetworkInterfaceInfo, ReferralEntry, ReferralEntryValue, Status};
+use smb_fscc::{ChainedItemList, FileBasicInformation, SetFileInfo, SetFileInfoClass};
+use smb_msg::{
+    AdditionalInfo, CloseRequest, CreateRequest, FileId, ImpersonationLevel, NetworkInterfaceInfo,
+    OplockLevel, RawSetInfoData, ReferralEntry, ReferralEntryValue, SetInfoClass, SetInfoData,
+    SetInfoRequest, ShareAccessFlags, Status,
+};
 use smb_rpc::interface::{LsaRpc, ShareInfo1, SrvSvc, TranslatedName};
 use smb_transport::TransportConfig;
 use smb_transport::utils::TransportUtils;
@@ -710,6 +716,140 @@ impl Client {
             Self::flush_eviction(&label, eviction).await;
         }
         Ok(count)
+    }
+
+    /// P2.b: compound `Create` + `SetInfo(FileBasicInformation)` + `Close`
+    /// into a single SMB2 compound request (MS-SMB2 3.2.4.1.4), saving
+    /// 2 wire round-trips compared with the open/set/close sequence
+    /// `update_metadata` would otherwise issue.
+    ///
+    /// Semantics:
+    /// - Opens `path` with `disposition = Open` and `access =
+    ///   FILE_WRITE_ATTRIBUTES` (the minimum to drive a SetInfo on
+    ///   FileBasicInformation per MS-SMB2 2.2.13.1.1).
+    /// - Issues SetInfo with the caller-provided `basic`. Per
+    ///   MS-FSCC 2.4.7, time-field values of 0 mean "preserve on the
+    ///   server" — callers can leave creation/change_time/file_attributes
+    ///   zeroed and only fill `last_access_time` / `last_write_time`.
+    /// - Closes the resulting handle immediately, so the SetInfo's
+    ///   sticky LastWriteTime gets committed to disk before this
+    ///   function returns. There is no lease, no deferred close, and
+    ///   no need for an `evict_lease` bracket around this call.
+    ///
+    /// The chain uses SMB2 related-operations semantics: the SetInfo and
+    /// Close members carry `FileId::FULL` (all-1s) and
+    /// `flags.related_operations = true`, telling the server to substitute
+    /// the FileId returned by the preceding Create (MS-SMB2 3.3.5.2.7.2).
+    ///
+    /// Returns `Err` if any of the three responses carries a non-success
+    /// status (the Create / SetInfo error is surfaced; the Close status is
+    /// checked last so a Close failure is reported separately).
+    pub async fn compound_set_basic_info(
+        &self,
+        path: &UncPath,
+        basic: FileBasicInformation,
+    ) -> crate::Result<()> {
+        let tree = self.get_tree(path).await?;
+        let tree_id = tree.tree_id();
+        let session = self.get_session(path).await?;
+        let session_id = session.session_id();
+        let signed = !session.allow_unsigned().await?;
+        let conn = self.get_connection(path.server()).await?;
+        let rel = path.path().unwrap_or("");
+
+        // --- Member 1: Create (Open) ---
+        // No lease context; we want immediate Close, not deferred. No DFS
+        // operations on this path — update_metadata is always against
+        // already-resolved paths under a connected share.
+        let create = CreateRequest {
+            requested_oplock_level: OplockLevel::None,
+            impersonation_level: ImpersonationLevel::Impersonation,
+            desired_access: smb_fscc::FileAccessMask::new().with_file_write_attributes(true),
+            file_attributes: smb_fscc::FileAttributes::new(),
+            share_access: ShareAccessFlags::new()
+                .with_read(true)
+                .with_write(true)
+                .with_delete(true),
+            create_disposition: smb_msg::CreateDisposition::Open,
+            create_options: smb_msg::CreateOptions::new(),
+            name: rel.into(),
+            contexts: ChainedItemList::default(),
+        };
+        let mut create_msg = OutgoingMessage::new(create.into());
+        create_msg.message.header.tree_id = Some(tree_id);
+        create_msg.message.header.session_id = session_id;
+        create_msg.message.header.flags.set_signed(signed);
+
+        // --- Member 2: SetInfo(FileBasicInformation) on the previous handle ---
+        // file_id = FULL + related_operations = true makes the server
+        // substitute Create's returned FileId here.
+        let setinfo = SetInfoRequest {
+            info_class: SetInfoClass::File(SetFileInfoClass::BasicInformation),
+            additional_information: AdditionalInfo::new(),
+            file_id: FileId::FULL,
+            data: SetInfoData::File(RawSetInfoData::from(SetFileInfo::BasicInformation(basic))),
+        };
+        let mut setinfo_msg = OutgoingMessage::new(setinfo.into());
+        setinfo_msg.message.header.tree_id = Some(tree_id);
+        setinfo_msg.message.header.session_id = session_id;
+        setinfo_msg.message.header.flags.set_signed(signed);
+        setinfo_msg
+            .message
+            .header
+            .flags
+            .set_related_operations(true);
+
+        // --- Member 3: Close on the same chained handle ---
+        let close = CloseRequest {
+            file_id: FileId::FULL,
+        };
+        let mut close_msg = OutgoingMessage::new(close.into());
+        close_msg.message.header.tree_id = Some(tree_id);
+        close_msg.message.header.session_id = session_id;
+        close_msg.message.header.flags.set_signed(signed);
+        close_msg
+            .message
+            .header
+            .flags
+            .set_related_operations(true);
+
+        let responses = conn
+            .send_compound(vec![create_msg, setinfo_msg, close_msg])
+            .await?;
+
+        // Validate each member's status. We surface the first non-success
+        // response (Create or SetInfo) explicitly because those are the
+        // path the caller cares about; a Close failure means we issued an
+        // orphan handle, which we want to know about but not as a primary
+        // error path.
+        if responses.len() != 3 {
+            return Err(Error::InvalidState(format!(
+                "compound_set_basic_info expected 3 responses, got {}",
+                responses.len()
+            )));
+        }
+        for (i, resp) in responses.iter().take(2).enumerate() {
+            let status = resp.message.header.status()?;
+            if !matches!(status, Status::Success) {
+                let kind = if i == 0 { "Create" } else { "SetInfo" };
+                tracing::error!(
+                    path = %path,
+                    member = kind,
+                    status = ?status,
+                    "compound_set_basic_info failed",
+                );
+                return Err(Error::UnexpectedMessageStatus(resp.message.header.status));
+            }
+        }
+        let close_status = responses[2].message.header.status()?;
+        if !matches!(close_status, Status::Success) {
+            tracing::warn!(
+                path = %path,
+                status = ?close_status,
+                "compound_set_basic_info: Close failed (server-side handle may leak until session end)",
+            );
+        }
+        Ok(())
     }
 
     /// Send the wire `Close` for an eviction that owes one. Failures are

--- a/crates/smb/src/client/smb_client.rs
+++ b/crates/smb/src/client/smb_client.rs
@@ -370,20 +370,53 @@ impl Client {
         let tree = self.get_tree(path).await?;
         let rel = path.path().unwrap_or("").to_string();
 
-        // Phase C.3 — cache-hit short-circuit. When the caller asked for a
-        // lease, look up the per-connection `lease_table`; the lookup and
-        // refcount bump happen atomically under the table lock via
-        // `try_acquire_lease`, which serializes us against concurrent
-        // `evict_lease` / `flush_idle_leases` operations so we never
-        // hand out a FileId the evicter has already closed on the wire.
-        if args.lease_request.is_some() {
+        // Phase D — inject the default lease when the caller didn't specify
+        // one and the client config opts in. The synthesized lease key is
+        // a deterministic mix of the client's `lease_key_salt` and the
+        // full UNC path, so repeat opens of the same path within this
+        // Client share a key (and hit the cache); different Clients on
+        // the same machine use different salts and therefore different
+        // keys (no cross-client server-side lease confusion).
+        let owned_args;
+        let effective_args = if args.lease_request.is_none() {
+            if let Some(state) = self.config.default_lease_state {
+                let lease = smb_msg::RequestLease::RqLsReqv2(smb_msg::RequestLeaseV2 {
+                    lease_key: Self::derive_lease_key(self.config.lease_key_salt, path),
+                    lease_state: state,
+                    lease_flags: smb_msg::LeaseFlags::new(),
+                    parent_lease_key: 0,
+                    epoch: 0,
+                });
+                owned_args = FileCreateArgs {
+                    disposition: args.disposition,
+                    attributes: args.attributes,
+                    options: args.options,
+                    desired_access: args.desired_access,
+                    lease_request: Some(lease),
+                };
+                &owned_args
+            } else {
+                args
+            }
+        } else {
+            args
+        };
+
+        // Phase C.3 — cache-hit short-circuit. When the (effective) args
+        // carry a lease request, look up the per-connection `lease_table`;
+        // the lookup and refcount bump happen atomically under the table
+        // lock via `try_acquire_lease`, which serializes us against
+        // concurrent `evict_lease` / `flush_idle_leases` operations so we
+        // never hand out a FileId the evicter has already closed on the
+        // wire.
+        if effective_args.lease_request.is_some() {
             if let Ok(conn) = self.get_connection(path.server()).await {
-                let wants_dir = args.options.directory_file();
+                let wants_dir = effective_args.options.directory_file();
                 if let Ok(Some(slot)) = conn
                     .try_acquire_lease(
                         &rel,
-                        args.desired_access,
-                        args.disposition,
+                        effective_args.desired_access,
+                        effective_args.disposition,
                         wants_dir,
                     )
                     .await
@@ -399,7 +432,7 @@ impl Client {
         }
 
         // Cache miss (or no lease requested): take the regular wire path.
-        let mut resource = tree.create(&rel, args).await?;
+        let mut resource = tree.create(&rel, effective_args).await?;
 
         // Phase C.1: install a slot into the per-connection cache so the
         // *next* call against the same path can hit C.3. Also attach the
@@ -407,7 +440,9 @@ impl Client {
         // through the deferred-close path (C.4).
         let grant = resource.handle().and_then(|h| h.lease_granted());
         if let Some(grant) = grant {
-            if let Some(proto) = resource.build_lease_proto(tree.handler_ref(), args.desired_access) {
+            if let Some(proto) =
+                resource.build_lease_proto(tree.handler_ref(), effective_args.desired_access)
+            {
                 let slot = std::sync::Arc::new(crate::lease::LeaseSlot::new_with_proto(
                     rel.clone(),
                     tree.tree_id(),
@@ -435,6 +470,32 @@ impl Client {
         }
 
         Ok(resource)
+    }
+
+    /// Derive a stable 128-bit lease key from the client's
+    /// `lease_key_salt` and the full UNC path. SipHash-flavored mix
+    /// avoids the bad cache behavior of a plain XOR (paths often share
+    /// long common prefixes) and gives enough entropy for the lease
+    /// cache to dedupe paths within a Client without collisions.
+    fn derive_lease_key(salt: u64, path: &UncPath) -> u128 {
+        use std::hash::{Hash, Hasher};
+        // Two independent hashers seeded with derived salts give us the
+        // two halves of the 128-bit key. Using `DefaultHasher` (SipHash
+        // under the hood) is good enough for collision resistance at
+        // this scale (a single Client rarely caches more than a few
+        // thousand paths).
+        let path_str = path.to_string();
+        let mut h_lo = std::collections::hash_map::DefaultHasher::new();
+        h_lo.write_u64(salt);
+        path_str.hash(&mut h_lo);
+        let lo = h_lo.finish() as u128;
+
+        let mut h_hi = std::collections::hash_map::DefaultHasher::new();
+        h_hi.write_u64(salt.wrapping_mul(0x9E3779B97F4A7C15));
+        path_str.hash(&mut h_hi);
+        let hi = h_hi.finish() as u128;
+
+        (hi << 64) | lo
     }
 
     /// Makes a connection to the specified server.

--- a/crates/smb/src/client/smb_client.rs
+++ b/crates/smb/src/client/smb_client.rs
@@ -369,6 +369,39 @@ impl Client {
     async fn _create_file(&self, path: &UncPath, args: &FileCreateArgs) -> crate::Result<Resource> {
         let tree = self.get_tree(path).await?;
         let resource = tree.create(path.path().unwrap_or(""), args).await?;
+
+        // Phase C.1: install a lease slot into the per-connection cache when
+        // the server granted a lease on this Create. Subsequent micro-steps
+        // (C.3) will check the cache *before* issuing Create at all; for
+        // now we only populate it so the next opens can observe the entry.
+        if let Some(handle) = resource.handle() {
+            if let Some(grant) = handle.lease_granted() {
+                let slot = std::sync::Arc::new(crate::lease::LeaseSlot::new(
+                    path.path().unwrap_or("").to_string(),
+                    tree.tree_id(),
+                    handle.raw_file_id(),
+                    grant.key,
+                    grant.state,
+                ));
+                match self.get_connection(path.server()).await {
+                    Ok(conn) => {
+                        if let Err(e) = conn.insert_lease_slot(slot).await {
+                            tracing::warn!(
+                                path = %path,
+                                error = ?e,
+                                "Failed to install lease slot in cache",
+                            );
+                        }
+                    }
+                    Err(e) => tracing::warn!(
+                        path = %path,
+                        error = ?e,
+                        "Cannot resolve connection for lease cache insert",
+                    ),
+                }
+            }
+        }
+
         Ok(resource)
     }
 

--- a/crates/smb/src/client/smb_client.rs
+++ b/crates/smb/src/client/smb_client.rs
@@ -368,31 +368,61 @@ impl Client {
 
     async fn _create_file(&self, path: &UncPath, args: &FileCreateArgs) -> crate::Result<Resource> {
         let tree = self.get_tree(path).await?;
-        let resource = tree.create(path.path().unwrap_or(""), args).await?;
+        let rel = path.path().unwrap_or("").to_string();
 
-        // Phase C.1: install a lease slot into the per-connection cache when
-        // the server granted a lease on this Create. Subsequent micro-steps
-        // (C.3) will check the cache *before* issuing Create at all; for
-        // now we only populate it so the next opens can observe the entry.
-        if let Some(handle) = resource.handle() {
-            if let Some(grant) = handle.lease_granted() {
-                let slot = std::sync::Arc::new(crate::lease::LeaseSlot::new(
-                    path.path().unwrap_or("").to_string(),
+        // Phase C.3 — cache-hit short-circuit. When the caller asked for a
+        // lease, check the per-connection lease_table first; if there's a
+        // live, non-tombstoned slot with a compatible access mask and the
+        // disposition is `Open`, materialize a fresh Resource from the
+        // slot without touching the wire. This is the actual RT-saving
+        // path that the rest of Phase C is built around.
+        if args.lease_request.is_some() {
+            if let Ok(conn) = self.get_connection(path.server()).await {
+                if let Ok(Some(slot)) = conn.peek_lease_slot(&rel).await {
+                    let wants_dir = args.options.directory_file();
+                    if slot.try_acquire_for_reuse(
+                        args.desired_access,
+                        args.disposition,
+                        wants_dir,
+                    ) {
+                        tracing::debug!(
+                            path = %rel,
+                            file_id = ?slot.file_id,
+                            "Lease cache hit; reusing FileId without Create RT",
+                        );
+                        return Ok(Resource::reuse_from_slot(slot));
+                    }
+                }
+            }
+        }
+
+        // Cache miss (or no lease requested): take the regular wire path.
+        let mut resource = tree.create(&rel, args).await?;
+
+        // Phase C.1: install a slot into the per-connection cache so the
+        // *next* call against the same path can hit C.3. Also attach the
+        // slot to the resource we're returning so its close()/Drop go
+        // through the deferred-close path (C.4).
+        let grant = resource.handle().and_then(|h| h.lease_granted());
+        if let Some(grant) = grant {
+            if let Some(proto) = resource.build_lease_proto(tree.handler_ref(), args.desired_access) {
+                let slot = std::sync::Arc::new(crate::lease::LeaseSlot::new_with_proto(
+                    rel.clone(),
                     tree.tree_id(),
-                    handle.raw_file_id(),
+                    resource.handle().map(|h| h.raw_file_id()).unwrap_or_default(),
                     grant.key,
                     grant.state,
+                    proto,
                 ));
                 match self.get_connection(path.server()).await {
-                    Ok(conn) => {
-                        if let Err(e) = conn.insert_lease_slot(slot).await {
-                            tracing::warn!(
-                                path = %path,
-                                error = ?e,
-                                "Failed to install lease slot in cache",
-                            );
-                        }
-                    }
+                    Ok(conn) => match conn.insert_lease_slot(slot.clone()).await {
+                        Ok(()) => resource.attach_lease_slot(slot),
+                        Err(e) => tracing::warn!(
+                            path = %path,
+                            error = ?e,
+                            "Failed to install lease slot in cache",
+                        ),
+                    },
                     Err(e) => tracing::warn!(
                         path = %path,
                         error = ?e,

--- a/crates/smb/src/connection.rs
+++ b/crates/smb/src/connection.rs
@@ -610,6 +610,68 @@ impl Connection {
     ) -> crate::Result<Option<Arc<LeaseSlot>>> {
         self.handler.peek_lease_slot(path).await
     }
+
+    /// Atomic cache-hit acquire: peek a slot and bump its refcount inside
+    /// the `lease_table` lock. See
+    /// [`ConnectionMessageHandler::try_acquire_lease`] for semantics and
+    /// the rationale around lock ordering vs eviction.
+    #[maybe_async]
+    pub async fn try_acquire_lease(
+        &self,
+        path: &str,
+        requested_access: smb_fscc::FileAccessMask,
+        requested_disposition: smb_msg::CreateDisposition,
+        wants_directory: bool,
+    ) -> crate::Result<Option<Arc<LeaseSlot>>> {
+        self.handler
+            .try_acquire_lease(path, requested_access, requested_disposition, wants_directory)
+            .await
+    }
+
+    /// Phase C.5: tombstone a lease slot and remove it from the table.
+    /// See [`ConnectionMessageHandler::take_lease_for_evict`] for the
+    /// race-free contract.
+    #[maybe_async]
+    pub async fn take_lease_for_evict(
+        &self,
+        path: &str,
+    ) -> crate::Result<Option<LeaseEviction>> {
+        self.handler.take_lease_for_evict(path).await
+    }
+
+    /// Phase C.5: scan the connection's lease table and tombstone any
+    /// slot whose `last_used` is older than `older_than`. Slots whose
+    /// refcount is zero at sweep time are removed from the table and
+    /// returned for the caller to flush the wire Close. Live-ref slots
+    /// stay in the table tombstoned; their last release_one will send
+    /// the deferred Close through the regular path.
+    #[maybe_async]
+    pub async fn sweep_idle_leases(
+        &self,
+        older_than: std::time::Duration,
+    ) -> crate::Result<Vec<LeaseEviction>> {
+        self.handler.sweep_idle_leases(older_than).await
+    }
+}
+
+/// Phase C.5: a slot that was just removed from the per-connection lease
+/// table because either an explicit `evict_lease` or an idle-sweep
+/// decided to flush it. The caller — `Client::evict_lease` /
+/// `Client::flush_idle_leases` — is responsible for sending the wire
+/// `Close` when `needs_wire_close` is true.
+pub struct LeaseEviction {
+    /// The slot that was removed from the table. Held as `Arc` since
+    /// live `ResourceHandle`s may still reference it; their close()/Drop
+    /// will see `tombstoned == true` and become no-ops on the table
+    /// (we already removed the entry).
+    pub slot: Arc<LeaseSlot>,
+    /// `true` when this eviction owns the wire `Close`: at removal time
+    /// the slot had zero live handles, so no `release_one` path will
+    /// fire it. The caller must send `CloseRequest` against
+    /// `slot.file_id` through `slot.proto.handler`. `false` when at
+    /// least one live handle was present; that handle's
+    /// `release_one` -> `CloseAndEvict` path will own the wire Close.
+    pub needs_wire_close: bool,
 }
 
 /// This struct is the internal message handler for the SMB client.
@@ -707,15 +769,120 @@ impl ConnectionMessageHandler {
     }
 
     /// Look up a cached lease slot by path. Returns `None` when there is
-    /// no entry. Phase C.3 will gate cache hits behind additional checks
-    /// (`tombstoned`, `granted_state` compatibility); this getter is the
-    /// raw lookup used by tests and the break-listener task.
+    /// no entry. Used by tests and the break-listener task; the cache-hit
+    /// fast path in `Client::_create_file` goes through
+    /// [`Self::try_acquire_lease`] instead so the bump is atomic with the
+    /// lookup against concurrent evictions.
     #[maybe_async]
     pub async fn peek_lease_slot(
         &self,
         path: &str,
     ) -> crate::Result<Option<Arc<LeaseSlot>>> {
         Ok(self.lease_table.lock().await?.get(path).cloned())
+    }
+
+    /// Phase C.5 race-free acquire: look up `path` and call
+    /// [`LeaseSlot::try_acquire_for_reuse`] *while still holding the
+    /// `lease_table` lock*. This serializes the refcount bump against
+    /// concurrent [`Self::take_lease_for_evict`] / [`Self::sweep_idle_leases`]
+    /// callers that also take the lock; without the lock the evict path
+    /// could observe `refcount == 0`, send a wire Close, and remove the
+    /// slot between an acquirer's `peek` and `fetch_add`, leaving the
+    /// acquirer with a stale FileId. Returns `Some(slot)` on a successful
+    /// bump, `None` for any non-hit reason.
+    #[maybe_async]
+    pub async fn try_acquire_lease(
+        &self,
+        path: &str,
+        requested_access: smb_fscc::FileAccessMask,
+        requested_disposition: smb_msg::CreateDisposition,
+        wants_directory: bool,
+    ) -> crate::Result<Option<Arc<LeaseSlot>>> {
+        let table = self.lease_table.lock().await?;
+        let Some(slot) = table.get(path).cloned() else {
+            return Ok(None);
+        };
+        if slot.try_acquire_for_reuse(requested_access, requested_disposition, wants_directory) {
+            Ok(Some(slot))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Phase C.5: atomically tombstone a slot keyed by `path`, remove it
+    /// from the table, and report whether the caller owes a wire Close.
+    /// The lock is held across the tombstone-store and the
+    /// `refcount.load`, so an `Acquire`-ordered `try_acquire_for_reuse`
+    /// running on another task either finishes its bump before this
+    /// function reads `refcount` (so we observe > 0 and yield the
+    /// close to that holder's `release_one`) or finds the slot gone
+    /// from the table and falls back to the wire Create path.
+    ///
+    /// Returns `None` when `path` had no entry.
+    #[maybe_async]
+    pub async fn take_lease_for_evict(
+        &self,
+        path: &str,
+    ) -> crate::Result<Option<LeaseEviction>> {
+        use std::sync::atomic::Ordering;
+        let mut table = self.lease_table.lock().await?;
+        let Some(slot) = table.remove(path) else {
+            return Ok(None);
+        };
+        slot.tombstoned.store(true, Ordering::Release);
+        let live = slot.refcount.load(Ordering::Acquire);
+        let needs_wire_close = live == 0;
+        tracing::debug!(
+            path = %slot.path,
+            live_handles = live,
+            needs_wire_close,
+            "Lease slot tombstoned and removed from table",
+        );
+        Ok(Some(LeaseEviction { slot, needs_wire_close }))
+    }
+
+    /// Phase C.5 idle sweep: walk the lease table, tombstone every slot
+    /// whose `last_used` predates `now - older_than`, and remove those
+    /// entries from the table. Slots with zero refcount at sweep time
+    /// are returned in the result so the caller can flush the wire
+    /// Close; slots with live handles stay tombstoned and rely on the
+    /// regular `release_one` -> `CloseAndEvict` path.
+    #[maybe_async]
+    pub async fn sweep_idle_leases(
+        &self,
+        older_than: std::time::Duration,
+    ) -> crate::Result<Vec<LeaseEviction>> {
+        use std::sync::atomic::Ordering;
+        let mut table = self.lease_table.lock().await?;
+        let cutoff = std::time::Instant::now()
+            .checked_sub(older_than)
+            .unwrap_or_else(std::time::Instant::now);
+
+        // Two-phase: collect victims first to avoid mutating while iterating.
+        let victims: Vec<String> = table
+            .iter()
+            .filter_map(|(k, slot)| match slot.last_used.read() {
+                Ok(ts) if *ts <= cutoff => Some(k.clone()),
+                _ => None,
+            })
+            .collect();
+
+        let mut out = Vec::with_capacity(victims.len());
+        for path in victims {
+            if let Some(slot) = table.remove(&path) {
+                slot.tombstoned.store(true, Ordering::Release);
+                let live = slot.refcount.load(Ordering::Acquire);
+                let needs_wire_close = live == 0;
+                tracing::debug!(
+                    path = %slot.path,
+                    live_handles = live,
+                    needs_wire_close,
+                    "Idle lease slot tombstoned and removed",
+                );
+                out.push(LeaseEviction { slot, needs_wire_close });
+            }
+        }
+        Ok(out)
     }
 
     /// Spawn a long-running task that consumes the lease-break broadcast

--- a/crates/smb/src/connection.rs
+++ b/crates/smb/src/connection.rs
@@ -7,7 +7,7 @@ pub mod worker;
 use crate::compression;
 use crate::connection::preauth_hash::PreauthHashState;
 use crate::dialects::DialectImpl;
-use crate::lease::LeaseBreakEvent;
+use crate::lease::{LeaseBreakEvent, LeaseSlot};
 use crate::session::ChannelMessageHandler;
 use crate::sync_helpers::*;
 use crate::{Error, crypto, msg_handler::*, session::Session};
@@ -524,6 +524,13 @@ impl Connection {
             );
             self.handler.handler.start_notify().await?;
             tracing::debug!("Notification job started.");
+
+            // Phase C.2: the break-listener consumes the per-connection
+            // lease_event_tx broadcast (fed by handle_lease_break) and
+            // tombstones matching slots in lease_table so new opens
+            // miss the cache after a server-side break.
+            #[cfg(feature = "async")]
+            self.handler.handler.start_lease_break_listener();
         }
 
         self.handler
@@ -581,6 +588,28 @@ impl Connection {
     ) -> tokio::sync::broadcast::Receiver<LeaseBreakEvent> {
         self.handler.subscribe_lease_breaks()
     }
+
+    /// Install a [`crate::lease::LeaseSlot`] into this connection's
+    /// lease cache. See [`ConnectionMessageHandler::insert_lease_slot`].
+    #[maybe_async]
+    pub async fn insert_lease_slot(&self, slot: Arc<LeaseSlot>) -> crate::Result<()> {
+        self.handler.insert_lease_slot(slot).await
+    }
+
+    /// Return the current number of cached lease slots.
+    #[maybe_async]
+    pub async fn lease_slot_count(&self) -> crate::Result<usize> {
+        self.handler.lease_slot_count().await
+    }
+
+    /// Look up a cached lease slot by path; `None` when absent.
+    #[maybe_async]
+    pub async fn peek_lease_slot(
+        &self,
+        path: &str,
+    ) -> crate::Result<Option<Arc<LeaseSlot>>> {
+        self.handler.peek_lease_slot(path).await
+    }
 }
 
 /// This struct is the internal message handler for the SMB client.
@@ -620,6 +649,13 @@ pub(crate) struct ConnectionMessageHandler {
     /// the existing notify path but do not fan them out.
     #[cfg(feature = "async")]
     lease_event_tx: tokio::sync::broadcast::Sender<LeaseBreakEvent>,
+
+    /// Per-connection cache of server-granted leases (Phase C). Keyed by
+    /// the file path relative to the share. Entries are inserted when a
+    /// `CreateResponse` carries an `RqLs` grant and removed when the last
+    /// holder drops *and* the slot is tombstoned. The actual `Close`
+    /// packet is deferred until destruction.
+    lease_table: Mutex<HashMap<String, Arc<LeaseSlot>>>,
 }
 
 impl ConnectionMessageHandler {
@@ -641,6 +677,141 @@ impl ConnectionMessageHandler {
             sessions: Mutex::new(HashMap::with_capacity(1)),
             #[cfg(feature = "async")]
             lease_event_tx,
+            lease_table: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Install a [`LeaseSlot`] into the per-connection cache. Called from
+    /// [`crate::Client::create_file`] after a successful Create that
+    /// carried an `RqLs` grant. Overwrites any prior entry for the same
+    /// path — a stale slot (e.g., a previous open that was closed by the
+    /// other side) is logically equivalent to no cache hit.
+    #[maybe_async]
+    pub async fn insert_lease_slot(&self, slot: Arc<LeaseSlot>) -> crate::Result<()> {
+        let key = slot.path.clone();
+        let mut table = self.lease_table.lock().await?;
+        if let Some(prev) = table.insert(key, slot) {
+            tracing::debug!(
+                path = %prev.path,
+                "Replaced existing lease slot in cache",
+            );
+        }
+        Ok(())
+    }
+
+    /// Return the current number of cached lease slots. Primarily for
+    /// observability and tests; not in any hot path.
+    #[maybe_async]
+    pub async fn lease_slot_count(&self) -> crate::Result<usize> {
+        Ok(self.lease_table.lock().await?.len())
+    }
+
+    /// Look up a cached lease slot by path. Returns `None` when there is
+    /// no entry. Phase C.3 will gate cache hits behind additional checks
+    /// (`tombstoned`, `granted_state` compatibility); this getter is the
+    /// raw lookup used by tests and the break-listener task.
+    #[maybe_async]
+    pub async fn peek_lease_slot(
+        &self,
+        path: &str,
+    ) -> crate::Result<Option<Arc<LeaseSlot>>> {
+        Ok(self.lease_table.lock().await?.get(path).cloned())
+    }
+
+    /// Spawn a long-running task that consumes the lease-break broadcast
+    /// and tombstones matching slots in `lease_table`. Idempotent — only
+    /// the first call subscribes; subsequent calls are no-ops. Async-only:
+    /// the broadcast channel doesn't exist in sync builds.
+    #[cfg(feature = "async")]
+    fn start_lease_break_listener(self: &Arc<Self>) {
+        use std::sync::atomic::Ordering;
+        let mut rx = self.lease_event_tx.subscribe();
+        let self_clone = self.clone();
+        let stop = self.stop_notifications.clone();
+        tokio::spawn(async move {
+            loop {
+                select! {
+                    _ = stop.cancelled() => {
+                        tracing::debug!("Lease break listener cancelled.");
+                        break;
+                    }
+                    next = rx.recv() => {
+                        match next {
+                            Ok(event) => {
+                                self_clone.apply_lease_break(&event).await;
+                            }
+                            Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                                // Listener fell behind the producer. The
+                                // ack for the missed events has already
+                                // been sent by handle_lease_break; the
+                                // only consequence here is that we may
+                                // miss some tombstones. The next break
+                                // for the same lease_key will recover us.
+                                tracing::warn!(
+                                    skipped,
+                                    "Lease break listener lagged; some tombstones may have been missed",
+                                );
+                            }
+                            Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                                tracing::debug!(
+                                    "Lease break channel closed; exiting listener.",
+                                );
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            tracing::debug!("Lease break listener task stopped.");
+            // Suppress unused warning when the underlying ordering import
+            // isn't needed by simpler future code paths.
+            let _ = Ordering::Relaxed;
+        });
+    }
+
+    /// Apply a single [`LeaseBreakEvent`] to the connection's lease table.
+    /// All slots whose `lease_key` matches the event are tombstoned and
+    /// their `granted_state` snapshot is updated to the server's new
+    /// state. Cache hits in C.3 will check `tombstoned` and miss when set.
+    #[cfg(feature = "async")]
+    async fn apply_lease_break(&self, event: &LeaseBreakEvent) {
+        use std::sync::atomic::Ordering;
+        let event_key = event.lease_key.as_u128();
+
+        // Snapshot the matching slots under a short critical section, then
+        // mutate outside the lock to keep the table responsive to other
+        // operations during the broadcast burst.
+        let matching: Vec<Arc<LeaseSlot>> = match self.lease_table.lock().await {
+            Ok(table) => table
+                .values()
+                .filter(|s| s.lease_key == event_key)
+                .cloned()
+                .collect(),
+            Err(e) => {
+                tracing::warn!(error = ?e, "lease_table lock poisoned during break apply");
+                return;
+            }
+        };
+
+        if matching.is_empty() {
+            tracing::trace!(
+                lease_key = ?event.lease_key,
+                "Break event has no matching slot in this connection's cache",
+            );
+            return;
+        }
+
+        for slot in matching {
+            slot.tombstoned.store(true, Ordering::Release);
+            if let Ok(mut state) = slot.granted_state.write() {
+                *state = event.new_state;
+            }
+            tracing::debug!(
+                path = %slot.path,
+                lease_key = %slot.lease_key,
+                new_state = ?event.new_state,
+                "Lease slot tombstoned by server break",
+            );
         }
     }
 

--- a/crates/smb/src/connection.rs
+++ b/crates/smb/src/connection.rs
@@ -652,6 +652,71 @@ impl Connection {
     ) -> crate::Result<Vec<LeaseEviction>> {
         self.handler.sweep_idle_leases(older_than).await
     }
+
+    /// Send an SMB2 compound chain through this connection's worker and
+    /// receive each member's response.
+    ///
+    /// For each message in `msgs` (in order) this:
+    /// 1. Sets `priority_mask` per the negotiated dialect — matches the
+    ///    single-message [`crate::msg_handler::MessageHandler::sendo`]
+    ///    path.
+    /// 2. Calls [`ConnectionMessageHandler::process_sequence_outgoing`]
+    ///    to allocate `message_id` + credit_charge / credit_request.
+    ///    Same accounting as a single-shot send, so server-side credit
+    ///    windows stay consistent.
+    /// 3. After all members are prepared, hands the whole batch to
+    ///    [`crate::connection::worker::WorkerImpl::send_compound`] for
+    ///    the single TCP write.
+    /// 4. Awaits each member's response separately via
+    ///    `Worker::receive` — server splits the compound response into
+    ///    N parts; our compound-aware incoming-side parser routes each
+    ///    part by message_id, and these receives just consume the
+    ///    pre-routed entries.
+    /// 5. Calls `process_sequence_incoming` on each response to return
+    ///    credits to the pool (mirroring the single-message path).
+    ///
+    /// The caller owns everything semantic: setting
+    /// `flags.related_operations` on members 2..N to chain off the
+    /// previous command's FileId/TreeId/SessionId, setting
+    /// `FileId::FULL` on commands that should reuse the prior result,
+    /// and validating each response's status code.
+    ///
+    /// On success returns `responses.len() == msgs.len()` in input order.
+    #[maybe_async]
+    pub async fn send_compound(
+        &self,
+        mut msgs: Vec<OutgoingMessage>,
+    ) -> crate::Result<Vec<IncomingMessage>> {
+        let priority_value = match self.handler.conn_info.get() {
+            Some(neg_info) => match neg_info.negotiation.dialect_rev {
+                Dialect::Smb0311 => 1,
+                _ => 0,
+            },
+            None => 0,
+        };
+        for m in msgs.iter_mut() {
+            m.message.header.flags = m.message.header.flags.with_priority_mask(priority_value);
+            self.handler.process_sequence_outgoing(m).await?;
+        }
+
+        let worker = self
+            .handler
+            .worker
+            .get()
+            .ok_or(Error::InvalidState("Worker is uninitialized".into()))?;
+        let send_results = worker.send_compound(msgs).await?;
+
+        let mut responses = Vec::with_capacity(send_results.len());
+        for r in send_results {
+            let mut opts = ReceiveOptions::new();
+            opts.msg_id = r.msg_id;
+            opts.allow_async = true;
+            let incoming = worker.receive(&opts).await?;
+            self.handler.process_sequence_incoming(&incoming).await?;
+            responses.push(incoming);
+        }
+        Ok(responses)
+    }
 }
 
 /// Phase C.5: a slot that was just removed from the per-connection lease

--- a/crates/smb/src/connection.rs
+++ b/crates/smb/src/connection.rs
@@ -815,13 +815,44 @@ impl ConnectionMessageHandler {
     /// other side) is logically equivalent to no cache hit.
     #[maybe_async]
     pub async fn insert_lease_slot(&self, slot: Arc<LeaseSlot>) -> crate::Result<()> {
+        use std::sync::atomic::Ordering;
         let key = slot.path.clone();
         let mut table = self.lease_table.lock().await?;
-        if let Some(prev) = table.insert(key, slot) {
+        let displaced = table.insert(key, slot);
+        drop(table);
+        if let Some(prev) = displaced {
+            // Tombstone the displaced slot. If a live ResourceHandle is
+            // still holding it (refcount > 0), its eventual close/Drop
+            // will see `CloseAndEvict` on release_one and send the wire
+            // `Close`. If the handle has already been dropped (refcount
+            // == 0 at displacement time), nobody will call release_one
+            // ever again, so we must send the wire Close ourselves —
+            // otherwise the server-side FileId leaks until session
+            // disconnect.
+            prev.tombstoned.store(true, Ordering::Release);
+            let live = prev.refcount.load(Ordering::Acquire);
             tracing::debug!(
                 path = %prev.path,
-                "Replaced existing lease slot in cache",
+                live_refs = live,
+                "Replaced existing lease slot in cache; old slot tombstoned",
             );
+            #[cfg(feature = "async")]
+            if live == 0 && prev.file_id != smb_msg::FileId::EMPTY {
+                let file_id = prev.file_id;
+                let handler = prev.proto.handler.clone();
+                tokio::spawn(async move {
+                    if let Err(e) =
+                        crate::resource::ResourceHandle::send_close_external(file_id, &handler)
+                            .await
+                    {
+                        tracing::warn!(
+                            file_id = ?file_id,
+                            error = ?e,
+                            "Displaced-slot wire Close failed (FileId leaked until session end)",
+                        );
+                    }
+                });
+            }
         }
         Ok(())
     }
@@ -918,10 +949,15 @@ impl ConnectionMessageHandler {
         older_than: std::time::Duration,
     ) -> crate::Result<Vec<LeaseEviction>> {
         use std::sync::atomic::Ordering;
+        // If `older_than` exceeds the elapsed time since this `Instant`
+        // monotonic clock began (e.g. caller passed `Duration::MAX`),
+        // there is nothing older than the cutoff — return immediately
+        // instead of the previous bug where the fallback `now` made
+        // every slot eligible for eviction.
+        let Some(cutoff) = std::time::Instant::now().checked_sub(older_than) else {
+            return Ok(Vec::new());
+        };
         let mut table = self.lease_table.lock().await?;
-        let cutoff = std::time::Instant::now()
-            .checked_sub(older_than)
-            .unwrap_or_else(std::time::Instant::now);
 
         // Two-phase: collect victims first to avoid mutating while iterating.
         let victims: Vec<String> = table
@@ -1002,27 +1038,52 @@ impl ConnectionMessageHandler {
     }
 
     /// Apply a single [`LeaseBreakEvent`] to the connection's lease table.
-    /// All slots whose `lease_key` matches the event are tombstoned and
-    /// their `granted_state` snapshot is updated to the server's new
-    /// state. Cache hits in C.3 will check `tombstoned` and miss when set.
+    /// All slots whose `lease_key` matches the event are tombstoned,
+    /// removed from the table, and their `granted_state` snapshot
+    /// updated to the server's new state.
+    ///
+    /// The tombstone-store, granted_state update, and table removal all
+    /// happen inside the `lease_table` lock so a concurrent
+    /// `try_acquire_lease` either runs first (and gets a still-valid
+    /// slot for which the wire I/O may racily fail — recoverable) or
+    /// runs after (and finds the slot gone, falling back to a fresh
+    /// wire Create). Without this fence the in-flight acquirer could
+    /// observe `tombstoned == false`, bump refcount, and hand out a
+    /// FileId the server has already revoked.
     #[cfg(feature = "async")]
     async fn apply_lease_break(&self, event: &LeaseBreakEvent) {
         use std::sync::atomic::Ordering;
         let event_key = event.lease_key.as_u128();
 
-        // Snapshot the matching slots under a short critical section, then
-        // mutate outside the lock to keep the table responsive to other
-        // operations during the broadcast burst.
-        let matching: Vec<Arc<LeaseSlot>> = match self.lease_table.lock().await {
-            Ok(table) => table
-                .values()
-                .filter(|s| s.lease_key == event_key)
-                .cloned()
-                .collect(),
-            Err(e) => {
-                tracing::warn!(error = ?e, "lease_table lock poisoned during break apply");
-                return;
-            }
+        let matching: Vec<Arc<LeaseSlot>> = {
+            let mut table = match self.lease_table.lock().await {
+                Ok(t) => t,
+                Err(e) => {
+                    tracing::warn!(error = ?e, "lease_table lock poisoned during break apply");
+                    return;
+                }
+            };
+
+            // Two-phase under the same lock: find victim paths first to
+            // sidestep "mutate while iterating", then remove + apply
+            // state transitions. Keeping both phases inside the lock
+            // closes the race against `try_acquire_lease`.
+            let victim_paths: Vec<String> = table
+                .iter()
+                .filter(|(_, slot)| slot.lease_key == event_key)
+                .map(|(k, _)| k.clone())
+                .collect();
+            victim_paths
+                .into_iter()
+                .filter_map(|p| {
+                    let slot = table.remove(&p)?;
+                    slot.tombstoned.store(true, Ordering::Release);
+                    if let Ok(mut state) = slot.granted_state.write() {
+                        *state = event.new_state;
+                    }
+                    Some(slot)
+                })
+                .collect()
         };
 
         if matching.is_empty() {
@@ -1032,17 +1093,12 @@ impl ConnectionMessageHandler {
             );
             return;
         }
-
-        for slot in matching {
-            slot.tombstoned.store(true, Ordering::Release);
-            if let Ok(mut state) = slot.granted_state.write() {
-                *state = event.new_state;
-            }
+        for slot in &matching {
             tracing::debug!(
                 path = %slot.path,
                 lease_key = %slot.lease_key,
                 new_state = ?event.new_state,
-                "Lease slot tombstoned by server break",
+                "Lease slot tombstoned + removed by server break",
             );
         }
     }

--- a/crates/smb/src/connection.rs
+++ b/crates/smb/src/connection.rs
@@ -7,6 +7,7 @@ pub mod worker;
 use crate::compression;
 use crate::connection::preauth_hash::PreauthHashState;
 use crate::dialects::DialectImpl;
+use crate::lease::LeaseBreakEvent;
 use crate::session::ChannelMessageHandler;
 use crate::sync_helpers::*;
 use crate::{Error, crypto, msg_handler::*, session::Session};
@@ -17,7 +18,10 @@ use maybe_async::*;
 use rand::RngCore;
 use rand::rngs::OsRng;
 use smb_dtyp::*;
-use smb_msg::{Command, Response, negotiate::*, plain::*, smb1::SMB1NegotiateMessage};
+use smb_msg::{
+    Command, RequestContent, Response, ResponseContent, negotiate::*,
+    oplock::LeaseBreakAck, smb1::SMB1NegotiateMessage,
+};
 use smb_transport::*;
 use std::cmp::max;
 use std::collections::HashMap;
@@ -25,8 +29,16 @@ use std::net::SocketAddr;
 #[cfg(feature = "multi_threaded")]
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::{AtomicU16, AtomicU64, Ordering};
+use std::time::Instant;
 pub use transformer::TransformError;
 use worker::{Worker, WorkerImpl};
+
+/// Capacity of the per-connection lease-break broadcast. A handful of slow
+/// subscribers wouldn't trail behind by more than this many events; if they
+/// do, they receive `RecvError::Lagged` and miss the older notifications —
+/// acceptable since the ack itself has already been sent by the connection
+/// task and the subscriber's role is just to invalidate cached state.
+const LEASE_BREAK_CHANNEL_CAPACITY: usize = 64;
 
 /// Represents an SMB connection.
 ///
@@ -498,9 +510,18 @@ impl Connection {
             .negotaite_complete(&info)
             .await;
 
+        // Always start the notify task unless the caller explicitly disabled
+        // it. `caps.notifications()` is the SMB 3.1.1 ChangeNotify capability
+        // and only modern Windows servers advertise it, but OplockBreak /
+        // LeaseBreak notifications are part of the base SMB 2.x protocol and
+        // every server can send them — we must always be ready to receive,
+        // ack, and dispatch them, otherwise lease handling silently breaks.
         #[cfg(not(feature = "single_threaded"))]
-        if !self.config.disable_notifications && info.negotiation.caps.notifications() {
-            tracing::debug!("Starting Notification job.");
+        if !self.config.disable_notifications {
+            tracing::debug!(
+                "Starting Notification job (server notifications cap={}).",
+                info.negotiation.caps.notifications()
+            );
             self.handler.handler.start_notify().await?;
             tracing::debug!("Notification job started.");
         }
@@ -551,6 +572,15 @@ impl Connection {
     pub fn conn_info(&self) -> Option<&Arc<ConnectionInfo>> {
         self.handler.conn_info.get()
     }
+
+    /// Subscribe to lease-break notifications received on this connection.
+    /// See [`ConnectionMessageHandler::subscribe_lease_breaks`] for semantics.
+    #[cfg(feature = "async")]
+    pub fn subscribe_lease_breaks(
+        &self,
+    ) -> tokio::sync::broadcast::Receiver<LeaseBreakEvent> {
+        self.handler.subscribe_lease_breaks()
+    }
 }
 
 /// This struct is the internal message handler for the SMB client.
@@ -583,10 +613,21 @@ pub(crate) struct ConnectionMessageHandler {
     /// The number of credits granted to the client by the server, including the being-used ones.
     /// This field is used ONLY when large MTU is enabled.
     credit_pool: AtomicU16,
+
+    /// Broadcasts [`LeaseBreakEvent`] to any [`crate::Client::subscribe_lease_breaks`]
+    /// consumers when the server sends a `LeaseBreakNotify`. Only present
+    /// under the `async` feature — sync builds receive notifications via
+    /// the existing notify path but do not fan them out.
+    #[cfg(feature = "async")]
+    lease_event_tx: tokio::sync::broadcast::Sender<LeaseBreakEvent>,
 }
 
 impl ConnectionMessageHandler {
     fn new(client_guid: Guid, credits_backlog: Option<u16>) -> ConnectionMessageHandler {
+        #[cfg(feature = "async")]
+        let (lease_event_tx, _) =
+            tokio::sync::broadcast::channel(LEASE_BREAK_CHANNEL_CAPACITY);
+
         ConnectionMessageHandler {
             client_guid,
             worker: OnceCell::new(),
@@ -598,7 +639,24 @@ impl ConnectionMessageHandler {
             #[cfg(not(feature = "single_threaded"))]
             stop_notifications: Default::default(),
             sessions: Mutex::new(HashMap::with_capacity(1)),
+            #[cfg(feature = "async")]
+            lease_event_tx,
         }
+    }
+
+    /// Subscribe to lease-break notifications received on this connection.
+    ///
+    /// Each call returns a fresh `Receiver`; sending is broadcast, so multiple
+    /// subscribers each see every event. Lagging subscribers may receive
+    /// `RecvError::Lagged` and skip older events — the connection task has
+    /// already sent the ack by that point, so missing the event only means
+    /// the subscriber's cache invalidation is delayed, never that the
+    /// protocol is left in a bad state.
+    #[cfg(feature = "async")]
+    pub fn subscribe_lease_breaks(
+        &self,
+    ) -> tokio::sync::broadcast::Receiver<LeaseBreakEvent> {
+        self.lease_event_tx.subscribe()
     }
 
     pub fn worker(&self) -> Option<&Arc<WorkerImpl>> {
@@ -720,17 +778,34 @@ impl ConnectionMessageHandler {
         let stop_notification = self.stop_notifications.clone();
         let self_clone = self.clone();
         tokio::spawn(async move {
+            // Race the cancellation token against each `rx.recv()` so that
+            // (a) we keep draining notifications as they arrive and
+            // (b) we exit promptly when the connection is shutting down.
+            //
+            // The previous form `select! { _ = cancelled() => break, else => { while let Some() } }`
+            // never entered the inner loop: `select!`'s `else` branch only
+            // fires when all named branches are *disabled* (via `if` guards),
+            // not when they are pending — so the task only waited for
+            // cancellation and never serviced any notification.
             loop {
                 select! {
                     _ = stop_notification.cancelled() => {
                         tracing::info!("Notification handler cancelled.");
                         break;
                     }
-                    else => {
-                        while let Some(msg) = rx.recv().await {
-                            self_clone.notify(msg).await.unwrap_or_else(|e| {
-                                tracing::error!("Error handling notification: {e:?}");
-                            });
+                    next = rx.recv() => {
+                        match next {
+                            Some(msg) => {
+                                if let Err(e) = self_clone.notify(msg).await {
+                                    tracing::error!("Error handling notification: {e:?}");
+                                }
+                            }
+                            None => {
+                                tracing::debug!(
+                                    "Notification channel closed; exiting handler."
+                                );
+                                break;
+                            }
                         }
                     }
                 }
@@ -852,6 +927,15 @@ impl MessageHandler for ConnectionMessageHandler {
 
     #[maybe_async]
     async fn notify(&self, msg: IncomingMessage) -> crate::Result<()> {
+        // Intercept LeaseBreakNotify *before* the session-id sanity check
+        // because the server sends lease breaks with `session_id = 0` per
+        // MS-SMB2 2.2.23.2 — the notification is keyed on lease_key, not
+        // on any particular session. We must ack and fan out the event
+        // promptly to stay within the 35-second break window.
+        if matches!(msg.message.content, ResponseContent::LeaseBreakNotify(_)) {
+            return self.handle_lease_break(msg).await;
+        }
+
         if msg.message.header.session_id == 0 {
             tracing::warn!("Received notification without session ID: {msg:?}");
             return Ok(());
@@ -879,6 +963,134 @@ impl MessageHandler for ConnectionMessageHandler {
 
         session.notify(msg).await?;
         Ok(())
+    }
+}
+
+impl ConnectionMessageHandler {
+    /// Process an incoming `LeaseBreakNotify`. Called from [`Self::notify`]
+    /// before any session forwarding so that:
+    ///
+    /// 1. Subscribers (Phase C `lease_table`, Phase D `cifs.rs::handle_cache`)
+    ///    learn about the broken lease as fast as possible and can flush
+    ///    cached `FileId` entries.
+    /// 2. The required `LeaseBreakAck` is sent back to the server inside
+    ///    the 35-second window, otherwise the server revokes the lease
+    ///    unilaterally and any deferred-close handles error on next use.
+    ///
+    /// Failures sending the ack are logged but not propagated — the
+    /// connection-wide notify loop must keep draining notifications even
+    /// if a single ack fails. Phase C will surface ack failures back to
+    /// the affected handle through the broadcast event.
+    #[maybe_async]
+    async fn handle_lease_break(&self, msg: IncomingMessage) -> crate::Result<()> {
+        let notify = match msg.message.content {
+            ResponseContent::LeaseBreakNotify(n) => n,
+            // SAFETY: caller (`Self::notify`) just matched the variant.
+            other => {
+                return Err(Error::InvalidState(format!(
+                    "handle_lease_break called with non-LeaseBreakNotify content: {other:?}"
+                )));
+            }
+        };
+
+        let ack_required = notify.ack_required != 0;
+        tracing::debug!(
+            lease_key = ?notify.lease_key,
+            current = ?notify.current_lease_state,
+            new = ?notify.new_lease_state,
+            ack_required,
+            "LeaseBreakNotify received"
+        );
+
+        // ACK FIRST (latency-critical path): NetApp-class clustered storage
+        // doesn't always wait the spec-mandated 60s for the ack before
+        // completing the open that caused the break — some tear down the
+        // lease entry as soon as they dispatch the notify, returning
+        // STATUS_NETWORK_NAME_DELETED for a "stale" ack. Send it before
+        // the in-memory broadcast so the wire-time gap is minimal.
+        if ack_required {
+            self.send_lease_break_ack(&notify).await;
+        }
+
+        // FAN OUT EVENT (after ack so wire-time is minimized)
+        //
+        // Subscribers (Phase C lease_table, Phase D cifs handle_cache)
+        // see this event regardless of whether the ack reached the server
+        // — they invalidate their cached state because the lease is
+        // logically broken from this moment on.
+        #[cfg(feature = "async")]
+        {
+            let event = LeaseBreakEvent {
+                lease_key: notify.lease_key,
+                current_state: notify.current_lease_state,
+                new_state: notify.new_lease_state,
+                epoch: notify.new_epoch,
+                ack_required,
+                received_at: Instant::now(),
+            };
+            // send returns Err only when there are zero active receivers,
+            // which is normal during early bring-up; ignore it.
+            let _ = self.lease_event_tx.send(event);
+        }
+
+        Ok(())
+    }
+
+    /// Construct and send a `LeaseBreakAck` for the given notification.
+    ///
+    /// Fire-and-forget (`has_response = false`): the server's
+    /// `LeaseBreakResponse` is purely informational, and waiting for it
+    /// would block the notify task. If it arrives later, the worker's
+    /// response router drops it as unmatched.
+    ///
+    /// The ack is sent through any active session on this connection so
+    /// it gets signed under the session key — sending unsigned via the
+    /// bare connection handler triggers STATUS_NETWORK_NAME_DELETED on
+    /// Samba-based servers. Lease identity is in the lease_key, not the
+    /// session, so the choice of session doesn't matter.
+    #[maybe_async]
+    async fn send_lease_break_ack(&self, notify: &smb_msg::LeaseBreakNotify) {
+        let session_handler = {
+            let sessions = match self.sessions.lock().await {
+                Ok(s) => s,
+                Err(e) => {
+                    tracing::warn!(
+                        lease_key = ?notify.lease_key,
+                        error = ?e,
+                        "Cannot send LeaseBreakAck: sessions lock poisoned",
+                    );
+                    return;
+                }
+            };
+            sessions.values().find_map(|w| w.upgrade())
+        };
+
+        let Some(h) = session_handler else {
+            tracing::warn!(
+                lease_key = ?notify.lease_key,
+                "Cannot send LeaseBreakAck: no active session on this connection",
+            );
+            return;
+        };
+
+        let ack = LeaseBreakAck {
+            lease_key: notify.lease_key,
+            lease_state: notify.new_lease_state,
+        };
+        let mut out = OutgoingMessage::new(RequestContent::LeaseBreakAck(ack));
+        out.has_response = false;
+        match h.sendo(out).await {
+            Ok(r) => tracing::debug!(
+                lease_key = ?notify.lease_key,
+                msg_id = r.msg_id,
+                "LeaseBreakAck sent (fire-and-forget)",
+            ),
+            Err(e) => tracing::warn!(
+                lease_key = ?notify.lease_key,
+                error = ?e,
+                "LeaseBreakAck send failed — server will revoke the lease",
+            ),
+        }
     }
 }
 

--- a/crates/smb/src/connection/transformer.rs
+++ b/crates/smb/src/connection/transformer.rs
@@ -265,6 +265,148 @@ impl Transformer {
         Ok(outgoing_data)
     }
 
+    /// Transforms an incoming message buffer to one or more [`IncomingMessage`]s,
+    /// supporting SMB2 compound responses.
+    ///
+    /// SMB2 compound responses chain multiple commands' responses into a single
+    /// TCP frame using the [`Header::next_command`] field (MS-SMB2 3.2.5.1.9 /
+    /// 3.3.4.1.5). Each member has its own header (including its own signature
+    /// when signing is on); the whole chain is encrypted/compressed as a unit if
+    /// either transformation is active.
+    ///
+    /// This method:
+    /// 1. Decrypts the chain (one shot) if [`Response::Encrypted`].
+    /// 2. Decompresses (one shot) if [`Response::Compressed`].
+    /// 3. Walks the resulting plain bytes, parsing one [`PlainResponse`] per
+    ///    NextCommand-delimited section, verifying each section's signature
+    ///    against just its own byte slice.
+    ///
+    /// Returns a `Vec` with one entry per member (length 1 in the common,
+    /// non-compound case). Member order matches the on-wire order, which the
+    /// server is required to preserve relative to the request chain (MS-SMB2
+    /// 3.3.5.2.7).
+    pub async fn transform_incoming_all(
+        &self,
+        data: Bytes,
+    ) -> crate::Result<Vec<IncomingMessage>> {
+        let message = Response::try_from(data.as_ref())?;
+        let mut form = MessageForm::default();
+
+        // 1. Decrypt (whole chain)
+        let (message, raw) = if let Response::Encrypted(encrypted_message) = message {
+            let session_id = encrypted_message.header.session_id;
+            form.encrypted = true;
+            let (msg, vec) = self
+                ._with_session(session_id, |session| {
+                    let decryptor = session.decryptor()?.ok_or(crate::Error::TranformFailed(
+                        TransformError {
+                            outgoing: false,
+                            phase: TransformPhase::EncryptDecrypt,
+                            session_id: Some(session_id),
+                            why: "Message is required to be encrypted, but no decryptor is set up!",
+                            msg_id: None,
+                        },
+                    ))?;
+                    decryptor.decrypt_message(encrypted_message)
+                })
+                .await?;
+            (msg, Bytes::from(vec))
+        } else {
+            (message, data)
+        };
+
+        // 2. Decompress (whole chain)
+        debug_assert!(!matches!(message, Response::Encrypted(_)));
+        let (message, raw) = if let Response::Compressed(compressed_message) = message {
+            let rconfig = self.config.read().await?;
+            form.compressed = true;
+            match &rconfig.compress {
+                Some(compress) => {
+                    let (msg, vec) = compress.1.decompress(&compressed_message)?;
+                    (msg, Bytes::from(vec))
+                }
+                None => {
+                    return Err(crate::Error::TranformFailed(TransformError {
+                        outgoing: false,
+                        phase: TransformPhase::CompressDecompress,
+                        session_id: None,
+                        why: "Compression is requested, but no decompressor is set up!",
+                        msg_id: None,
+                    }));
+                }
+            }
+        } else {
+            (message, raw)
+        };
+
+        let plain = match message {
+            Response::Plain(p) => p,
+            _ => {
+                return Err(crate::Error::InvalidMessage(
+                    "Expected plain message after decryption/decompression".to_string(),
+                ));
+            }
+        };
+
+        // 3. Walk the compound chain (or return single).
+        //    `next_command == 0` means this is the last (or only) member.
+        let mut out: Vec<IncomingMessage> = Vec::new();
+        let mut current = plain;
+        let mut remaining = raw;
+        loop {
+            let next_offset = current.header.next_command as usize;
+            // The slice belonging to *this* member is `remaining[..next_offset]`
+            // when there's another command after it, else the whole rest of
+            // `remaining`. Signing/verification is per-member over this slice.
+            let this_slice = if next_offset > 0 {
+                if next_offset > remaining.len() {
+                    return Err(crate::Error::InvalidMessage(format!(
+                        "Compound NextCommand offset {next_offset} exceeds remaining buffer {}",
+                        remaining.len()
+                    )));
+                }
+                remaining.slice(0..next_offset)
+            } else {
+                remaining.clone()
+            };
+
+            let mut member_form = form;
+            if let Err(e) = self
+                .verify_plain_incoming(&mut current, &this_slice, &mut member_form)
+                .await
+            {
+                tracing::error!("Failed to verify compound member message: {e:?}");
+                return Err(crate::Error::TranformFailed(TransformError {
+                    outgoing: false,
+                    phase: TransformPhase::SignVerify,
+                    session_id: Some(current.header.session_id),
+                    why: "Failed to verify compound member signature!",
+                    msg_id: Some(current.header.message_id),
+                }));
+            }
+            out.push(IncomingMessage::new(current, this_slice, member_form));
+
+            if next_offset == 0 {
+                break;
+            }
+            remaining = remaining.slice(next_offset..);
+            // Parse next member's header + content from the new slice start.
+            let next_resp = Response::try_from(remaining.as_ref())?;
+            current = match next_resp {
+                Response::Plain(p) => p,
+                _ => {
+                    return Err(crate::Error::InvalidMessage(
+                        "Compound chain member must be a plain SMB2 response \
+                         (encryption/compression apply to the whole chain only)"
+                            .to_string(),
+                    ));
+                }
+            };
+        }
+
+        Ok(out)
+    }
+
     /// Transforms an incoming message buffer to an [`IncomingMessage`].
     ///
     /// Accepts `Bytes` for zero-copy slicing of the raw data in downstream consumers.

--- a/crates/smb/src/connection/transformer.rs
+++ b/crates/smb/src/connection/transformer.rs
@@ -155,6 +155,153 @@ impl Transformer {
         f(&session_info)
     }
 
+    /// Build the wire bytes for an SMB2 compound chain (MS-SMB2 3.2.4.1.4):
+    /// multiple SMB2 commands concatenated in one TCP send, each with its own
+    /// header carrying a `NextCommand` offset to the next member.
+    ///
+    /// Behavior summary:
+    /// - Each member is serialized independently (header + content).
+    /// - Each header's `next_command` is set to the 8-byte-aligned length of
+    ///   that member (0 for the last). Headers are re-written to capture this.
+    /// - Each member is then padded to 8-byte alignment as required by the spec.
+    /// - Signing is per-member: each header's signature is computed over just
+    ///   that member's byte slice (header with signature=0 + body), then written
+    ///   back into the header. All members must have the same `signed` flag on
+    ///   the first member (used as the chain-wide policy).
+    /// - The resulting [`IoVec`] is the concatenation of each member's bytes
+    ///   in order, ready for the transport to write.
+    ///
+    /// **Constraints for the current minimal implementation:**
+    /// - No encryption.
+    /// - No compression.
+    /// - No `additional_data` zero-copy bodies (data is whatever each
+    ///   member's `PlainRequest` serializes to).
+    /// - Caller must have already populated `header.message_id`,
+    ///   `tree_id`, `session_id`, and `credit_charge` / `credit_request`
+    ///   per member (typically done by `Connection::process_sequence_outgoing`
+    ///   on each message before this call).
+    /// - Caller is responsible for setting `flags.related_operations` on the
+    ///   2nd..Nth members and the `0xFF…FF` sentinel `FileId` on commands that
+    ///   want to chain context from a prior Create.
+    ///
+    /// Returns `Err(InvalidArgument)` for an empty `msgs` slice or any
+    /// member that requests encryption / additional_data.
+    pub async fn transform_outgoing_compound(
+        &self,
+        mut msgs: Vec<OutgoingMessage>,
+    ) -> crate::Result<IoVec> {
+        if msgs.is_empty() {
+            return Err(crate::Error::InvalidArgument(
+                "compound chain requires at least one message".to_string(),
+            ));
+        }
+        for (i, m) in msgs.iter().enumerate() {
+            if m.encrypt {
+                return Err(crate::Error::InvalidArgument(format!(
+                    "compound member {i}: encryption is not supported in the current minimal compound path",
+                )));
+            }
+            if m.additional_data.is_some() {
+                return Err(crate::Error::InvalidArgument(format!(
+                    "compound member {i}: additional_data is not supported in compound mode",
+                )));
+            }
+        }
+
+        // 1. Serialize each member's bytes (header + content). Header still
+        //    has its old `next_command = 0` here; we rewrite it in step 2.
+        let mut member_bufs: Vec<Vec<u8>> = Vec::with_capacity(msgs.len());
+        for m in &msgs {
+            let mut buf = Vec::with_capacity(Header::STRUCT_SIZE + 256);
+            m.message.write(&mut Cursor::new(&mut buf))?;
+            member_bufs.push(buf);
+        }
+
+        // 2. Compute next_command offsets and rewrite each member's header bytes.
+        //    For member i (except last): next_command = 8-byte-aligned len of member i's buffer.
+        //    For last member: next_command = 0 (already).
+        let last = msgs.len() - 1;
+        for i in 0..last {
+            let aligned = (member_bufs[i].len() + 7) & !7usize;
+            msgs[i].message.header.next_command = u32::try_from(aligned).map_err(|_| {
+                crate::Error::InvalidState(format!(
+                    "compound member {i}: aligned size {aligned} does not fit in u32",
+                ))
+            })?;
+            // Rewrite the header bytes in-place with the updated next_command.
+            let mut header_bytes = [0u8; Header::STRUCT_SIZE];
+            msgs[i]
+                .message
+                .header
+                .write(&mut Cursor::new(&mut header_bytes[..]))?;
+            member_bufs[i][..Header::STRUCT_SIZE].copy_from_slice(&header_bytes);
+        }
+
+        // 3. Sign each member if signing is requested (per-member, over that
+        //    member's bytes only). We snapshot the signer once and reuse it
+        //    for each member (MessageSigner clone is cheap — no heap alloc).
+        let should_sign = msgs[0].message.header.flags.signed();
+        if should_sign {
+            let session_id = msgs[0].message.header.session_id;
+            let signer = self
+                ._with_channel(session_id, |session| {
+                    let channel_info =
+                        session
+                            .channel
+                            .as_ref()
+                            .ok_or(crate::Error::TranformFailed(TransformError {
+                                outgoing: true,
+                                phase: TransformPhase::SignVerify,
+                                session_id: Some(session_id),
+                                why: "Compound message is signed, but no channel signer is set up",
+                                msg_id: None,
+                            }))?;
+                    Ok(channel_info.signer()?.clone())
+                })
+                .await?;
+
+            for i in 0..msgs.len() {
+                let mut iov: IoVec = IoVec::from(std::mem::take(&mut member_bufs[i]));
+                let mut signer = signer.clone();
+                signer.sign_message(&mut msgs[i].message.header, &mut iov)?;
+                // After sign_message, iov[0] holds the buffer with the signature
+                // written back into the header. Move it back into member_bufs
+                // without copying (IoVecBuf::Owned -> Vec via mem::take).
+                match &mut iov[0] {
+                    smb_transport::IoVecBuf::Owned(v) => {
+                        member_bufs[i] = std::mem::take(v);
+                    }
+                    smb_transport::IoVecBuf::Shared(_) => {
+                        return Err(crate::Error::InvalidState(
+                            "signed compound member buffer was not owned".to_string(),
+                        ));
+                    }
+                }
+                tracing::trace!(
+                    "Compound member {i} (msg_id {}) signed (signature={}).",
+                    msgs[i].message.header.message_id,
+                    msgs[i].message.header.signature,
+                );
+            }
+        }
+
+        // 4. Pad each member except the last to 8-byte alignment. The
+        //    `next_command` offset we set in step 2 must match the padded
+        //    length so the server's parser advances to the right place.
+        for i in 0..last {
+            let aligned = (member_bufs[i].len() + 7) & !7usize;
+            member_bufs[i].resize(aligned, 0);
+        }
+
+        // 5. Concatenate into the output IoVec. Each member is its own
+        //    owned buffer — the transport will gather them on send.
+        let mut out = IoVec::default();
+        for buf in member_bufs {
+            out.add_owned(buf);
+        }
+        Ok(out)
+    }
+
     /// Transforms an outgoing message to a raw SMB message.
     pub async fn transform_outgoing(&self, mut msg: OutgoingMessage) -> crate::Result<IoVec> {
         let should_encrypt = msg.encrypt;

--- a/crates/smb/src/connection/transformer.rs
+++ b/crates/smb/src/connection/transformer.rs
@@ -237,9 +237,22 @@ impl Transformer {
             member_bufs[i][..Header::STRUCT_SIZE].copy_from_slice(&header_bytes);
         }
 
-        // 3. Sign each member if signing is requested (per-member, over that
-        //    member's bytes only). We snapshot the signer once and reuse it
-        //    for each member (MessageSigner clone is cheap — no heap alloc).
+        // 3. Pad each non-last member to 8-byte alignment FIRST. The
+        //    `next_command` offset we set in step 2 is the padded length,
+        //    and per MS-SMB2 3.1.4.1 the per-member signature MUST cover
+        //    the full byte range the server sees as "this command", i.e.
+        //    the padded buffer. Signing must therefore happen AFTER
+        //    padding so the HMAC input matches what the receiver
+        //    re-hashes during verification.
+        for i in 0..last {
+            let aligned = (member_bufs[i].len() + 7) & !7usize;
+            member_bufs[i].resize(aligned, 0);
+        }
+
+        // 4. Sign each member if signing is requested (per-member, over
+        //    that member's padded bytes). We snapshot the signer once
+        //    and reuse it for each member (MessageSigner clone is cheap
+        //    — no heap alloc).
         let should_sign = msgs[0].message.header.flags.signed();
         if should_sign {
             let session_id = msgs[0].message.header.session_id;
@@ -283,14 +296,6 @@ impl Transformer {
                     msgs[i].message.header.signature,
                 );
             }
-        }
-
-        // 4. Pad each member except the last to 8-byte alignment. The
-        //    `next_command` offset we set in step 2 must match the padded
-        //    length so the server's parser advances to the right place.
-        for i in 0..last {
-            let aligned = (member_bufs[i].len() + 7) & !7usize;
-            member_bufs[i].resize(aligned, 0);
         }
 
         // 5. Concatenate into the output IoVec. Each member is its own

--- a/crates/smb/src/connection/worker/parallel/base.rs
+++ b/crates/smb/src/connection/worker/parallel/base.rs
@@ -91,6 +91,61 @@ where
         self.stopped.load(Ordering::Relaxed)
     }
 
+    /// Send a compound SMB2 request chain (MS-SMB2 3.2.4.1.4): N messages
+    /// stitched together via `Header::next_command`, sent in a single TCP
+    /// write. Returns one [`SendMessageResult`] per member (in order), so
+    /// the caller can later `receive(msg_id)` each member's response
+    /// independently.
+    ///
+    /// Compound responses come back the same way: server packs N
+    /// responses into one frame and the worker's `incoming_data_callback`
+    /// fans each out to its matching `msg_id` waiter via
+    /// `Transformer::transform_incoming_all` — there's nothing extra to
+    /// do on the receive side from the caller.
+    ///
+    /// **The caller is responsible for**:
+    /// - allocating `message_id` (and credit_charge / credit_request) for
+    ///   each member before this call, typically by running each through
+    ///   `Connection::process_sequence_outgoing`;
+    /// - setting `flags.related_operations = true` on members 2..N if the
+    ///   chain is using the related-operations / `FileId::FULL` chaining
+    ///   semantics from MS-SMB2 3.3.5.2.7.2.
+    ///
+    /// **Not supported in the minimal compound path** (will error):
+    /// - per-member encryption,
+    /// - per-member `additional_data` (zero-copy write tails),
+    /// - empty input.
+    pub async fn send_compound(
+        self: &Arc<Self>,
+        msgs: Vec<OutgoingMessage>,
+    ) -> crate::Result<Vec<SendMessageResult>> {
+        if msgs.is_empty() {
+            return Err(Error::InvalidArgument(
+                "send_compound: empty message list".to_string(),
+            ));
+        }
+        // Snapshot ids before consuming `msgs` so we can return them as
+        // SendMessageResult after the transform.
+        let ids: Vec<u64> = msgs
+            .iter()
+            .map(|m| m.message.header.message_id)
+            .collect();
+
+        let raw = self.transformer.transform_outgoing_compound(msgs).await?;
+        tracing::trace!(
+            "Compound chain ({} members, ids={ids:?}) handed to transport.",
+            ids.len()
+        );
+
+        let message = T::wrap_msg_to_send(raw);
+        T::channel_send(&self.sender, message)?;
+
+        Ok(ids
+            .into_iter()
+            .map(|id| SendMessageResult::new(id, None))
+            .collect())
+    }
+
     /// This is a function that should be used by multi worker implementations (async/mtd),
     /// after gettting a messages from the server, this function processes it and
     /// notifies the awaiting tasks.

--- a/crates/smb/src/connection/worker/parallel/base.rs
+++ b/crates/smb/src/connection/worker/parallel/base.rs
@@ -101,17 +101,19 @@ where
         tracing::trace!("Received message from server.");
         let message = message?;
 
-        // Tranform the message and verify it.
-        let msg = self.transformer.transform_incoming(message).await;
-        let (msg, msg_id) = match msg {
-            // Good flow, message is OK.
-            Ok(msg) => {
-                let msg_id = msg.message.header.message_id;
-                (Ok(msg), msg_id)
-            }
-            // If we have a message ID to notify the error, use it.
+        // Transform the message(s). A single NetBIOS frame can contain a
+        // compound chain of N responses (SMB2 NextCommand); we dispatch each
+        // chained response to its own awaiter independently.
+        let msgs = match self.transformer.transform_incoming_all(message).await {
+            Ok(v) => v,
+            // If the transformer can attribute the failure to a single
+            // message id, route the error to that awaiter; otherwise propagate.
             Err(crate::Error::TranformFailed(e)) => match e.msg_id {
-                Some(msg_id) => (Err(crate::Error::TranformFailed(e)), msg_id),
+                Some(msg_id) => {
+                    return self
+                        .dispatch_one(msg_id, Err(crate::Error::TranformFailed(e)))
+                        .await;
+                }
                 None => return Err(Error::TranformFailed(e)),
             },
             Err(e) => {
@@ -120,17 +122,27 @@ where
             }
         };
 
+        for msg in msgs {
+            let msg_id = msg.message.header.message_id;
+            self.dispatch_one(msg_id, Ok(msg)).await?;
+        }
+        Ok(())
+    }
+
+    /// Route a single parsed message (or transform error) to its awaiting
+    /// caller. msg_id == u64::MAX is the unsolicited-notification path
+    /// (oplock/lease break, server-to-client).
+    async fn dispatch_one(
+        self: &Arc<Self>,
+        msg_id: u64,
+        msg: crate::Result<IncomingMessage>,
+    ) -> crate::Result<()> {
         // Message ID (-1) is used and valid for notifications -
         // OPLOCK_BREAK or SERVER_TO_CLIENT_NOTIFICATION only.
         if msg_id == u64::MAX {
-            // Nothing's waiting, so if there was an error, return it --
-            // no need to notify anyone else.
             let msg = msg?;
 
             // Server-to-client commands check.
-            // Allow oplock break / lease break notifications and server-to-client
-            // notifications. (`*Break` ack-response messages carry a regular
-            // request_id and never take this unsolicited branch.)
             if !matches!(
                 msg.message.content,
                 ResponseContent::OplockBreakNotify(_)

--- a/crates/smb/src/connection/worker/parallel/base.rs
+++ b/crates/smb/src/connection/worker/parallel/base.rs
@@ -128,14 +128,17 @@ where
             let msg = msg?;
 
             // Server-to-client commands check.
-            // allow only oplock break and server to client notification.
+            // Allow oplock break / lease break notifications and server-to-client
+            // notifications. (`*Break` ack-response messages carry a regular
+            // request_id and never take this unsolicited branch.)
             if !matches!(
                 msg.message.content,
                 ResponseContent::OplockBreakNotify(_)
+                    | ResponseContent::LeaseBreakNotify(_)
                     | ResponseContent::ServerToClientNotification(_)
             ) {
                 return Err(Error::MessageProcessingError(
-                    "Received notification message, but not an OPLOCK_BREAK or SERVER_TO_CLIENT_NOTIFICATION.".to_string(),
+                    "Received notification message, but not an OPLOCK_BREAK / LEASE_BREAK / SERVER_TO_CLIENT_NOTIFICATION.".to_string(),
                 ));
             }
 

--- a/crates/smb/src/lease.rs
+++ b/crates/smb/src/lease.rs
@@ -1,0 +1,56 @@
+//! Client-side SMB lease lifecycle events.
+//!
+//! Phase A wired up the *request + grant* side of SMB Handle Lease via
+//! [`crate::FileCreateArgs::lease_request`] and [`crate::LeaseGrant`].
+//! Phase B (this module) adds the *break* side: the server can, at any time,
+//! notify the client that a previously-granted lease is being revoked or
+//! downgraded (MS-SMB2 2.2.23.2). The client must reply with a
+//! `LeaseBreakAck` within roughly 35 seconds, or the server will revoke the
+//! lease unilaterally.
+//!
+//! This module exposes a [`LeaseBreakEvent`] type that mirrors the on-wire
+//! `LeaseBreakNotify` plus a timestamp, and a broadcast channel on
+//! [`crate::Client`] (via `Client::subscribe_lease_breaks`) so higher layers
+//! (Phase C `lease_table`, Phase D `cifs.rs::handle_cache`) can react to
+//! invalidations.
+
+use smb_dtyp::Guid;
+use smb_msg::LeaseState;
+use std::time::Instant;
+
+/// A single lease-break notification received from the server, normalized
+/// into a `Copy`-cheap form for fan-out across subscribers.
+///
+/// The client-side reaction is two-step:
+/// 1. Receive the [`LeaseBreakEvent`] (this struct) and start invalidating
+///    any cached state keyed on `lease_key`.
+/// 2. Send a `LeaseBreakAck` back to the server within the 35-second timeout.
+///    Phase B sends the ack automatically before publishing the event; Phase C
+///    will additionally drive any deferred `Close` for the affected handle.
+///
+/// Reference: MS-SMB2 2.2.23.2 (LeaseBreakNotification).
+#[derive(Debug, Clone, Copy)]
+pub struct LeaseBreakEvent {
+    /// Client-generated key that identifies the lease being broken. Matches
+    /// the value the client originally placed in `RequestLease.lease_key`.
+    pub lease_key: Guid,
+    /// The lease state the client currently holds, per the server's view.
+    /// In normal operation this matches what the server most recently
+    /// granted; a divergence usually means concurrent break notifications.
+    pub current_state: LeaseState,
+    /// The lease state the server wants to downgrade to. Often `0` (full
+    /// revocation), occasionally a subset (e.g., losing `write_caching`
+    /// while keeping `read_caching`).
+    pub new_state: LeaseState,
+    /// Epoch value used to track lease-state changes for v2 leases.
+    /// Zero for v1 leases (SMB 2.1) or when the server isn't tracking
+    /// epochs for this open.
+    pub epoch: u16,
+    /// `true` when the server expects a `LeaseBreakAck` reply within the
+    /// 35-second timeout. `false` indicates the server is just informing
+    /// us of an unconditional downgrade; no reply is required.
+    pub ack_required: bool,
+    /// Wall-clock instant the client received the notification, used for
+    /// observability and to drive ack-timeout backstops in Phase C.
+    pub received_at: Instant,
+}

--- a/crates/smb/src/lease.rs
+++ b/crates/smb/src/lease.rs
@@ -1,21 +1,23 @@
-//! Client-side SMB lease lifecycle events.
+//! Client-side SMB lease lifecycle events and cache.
 //!
 //! Phase A wired up the *request + grant* side of SMB Handle Lease via
 //! [`crate::FileCreateArgs::lease_request`] and [`crate::LeaseGrant`].
-//! Phase B (this module) adds the *break* side: the server can, at any time,
-//! notify the client that a previously-granted lease is being revoked or
-//! downgraded (MS-SMB2 2.2.23.2). The client must reply with a
-//! `LeaseBreakAck` within roughly 35 seconds, or the server will revoke the
-//! lease unilaterally.
+//! Phase B added the *break* side: the server can, at any time, notify the
+//! client that a previously-granted lease is being revoked or downgraded
+//! (MS-SMB2 2.2.23.2). This module exposes [`LeaseBreakEvent`] mirroring the
+//! on-wire `LeaseBreakNotify` plus a timestamp.
 //!
-//! This module exposes a [`LeaseBreakEvent`] type that mirrors the on-wire
-//! `LeaseBreakNotify` plus a timestamp, and a broadcast channel on
-//! [`crate::Client`] (via `Client::subscribe_lease_breaks`) so higher layers
-//! (Phase C `lease_table`, Phase D `cifs.rs::handle_cache`) can react to
-//! invalidations.
+//! Phase C introduces the [`LeaseSlot`] cache: when the server grants a
+//! lease, the connection holds onto the FileId so subsequent Opens against
+//! the same path can be served from cache (skipping the Create RT). The
+//! actual `Close` is deferred until either (a) the last live reference
+//! drops *and* the slot has been tombstoned, or (b) an explicit eviction
+//! runs (e.g. before `delete` or `rename`).
 
 use smb_dtyp::Guid;
-use smb_msg::LeaseState;
+use smb_msg::{FileId, LeaseState};
+use std::sync::RwLock;
+use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::time::Instant;
 
 /// A single lease-break notification received from the server, normalized
@@ -53,4 +55,76 @@ pub struct LeaseBreakEvent {
     /// Wall-clock instant the client received the notification, used for
     /// observability and to drive ack-timeout backstops in Phase C.
     pub received_at: Instant,
+}
+
+/// A cached, lease-protected open. Owned by the
+/// connection's `lease_table`; multiple [`crate::ResourceHandle`] instances
+/// may share an `Arc<LeaseSlot>` and operate on the same server-side
+/// `FileId`. The actual `Close` is deferred until both:
+///
+/// 1. The slot's `refcount` drops to zero — no live handle references it.
+/// 2. The slot is `tombstoned` — either by a server-side
+///    `LeaseBreakNotify` that dropped enough caching bits, or by an
+///    explicit `Client::evict_lease` call before a destructive op.
+///
+/// Until both conditions are met, the FileId stays live on the server and
+/// new Opens against the same path hit the cache for free.
+///
+/// Phase C lays down the type and the insert path; cache hits, deferred
+/// close, and break-driven tombstoning land in later micro-steps of the
+/// same phase.
+pub struct LeaseSlot {
+    /// The file path (relative to the share root) the lease was opened
+    /// against. Used as the lookup key inside the per-connection table
+    /// and for diagnostic logs.
+    pub path: String,
+    /// Tree the original Create was issued on. Future cache hits must
+    /// reuse the same tree so per-tree access permissions match.
+    pub tree_id: u32,
+    /// Server-assigned FileId for the open. Cached hits reuse this FileId
+    /// on every operation; the wire `Close` is only sent when the slot is
+    /// destroyed.
+    pub file_id: FileId,
+    /// Client-generated lease key, normalized to u128 so it can be
+    /// matched against [`LeaseBreakEvent::lease_key`] via [`Guid::as_u128`].
+    pub lease_key: u128,
+    /// Current granted lease state. The break-listener task downgrades
+    /// this under `write` when the server's `LeaseBreakNotify` says so.
+    pub granted_state: RwLock<LeaseState>,
+    /// Number of live [`crate::ResourceHandle`] clones referencing this
+    /// slot. The wire `Close` is deferred until this hits zero *and* the
+    /// slot is tombstoned.
+    pub refcount: AtomicUsize,
+    /// `true` once the lease is no longer eligible for new cache hits —
+    /// either a server break dropped caching bits, or the caller
+    /// explicitly evicted. The next `refcount == 0` transition triggers
+    /// the real `Close`.
+    pub tombstoned: AtomicBool,
+    /// Last time the slot was created or hit. Used by
+    /// `flush_idle_leases(Duration)` to evict slots whose lease the
+    /// server may have silently dropped on its side.
+    pub last_used: RwLock<Instant>,
+}
+
+impl LeaseSlot {
+    /// Construct a new slot from a successful Create response. Initial
+    /// refcount is `1` (the caller's handle), not tombstoned.
+    pub fn new(
+        path: String,
+        tree_id: u32,
+        file_id: FileId,
+        lease_key: u128,
+        granted_state: LeaseState,
+    ) -> Self {
+        Self {
+            path,
+            tree_id,
+            file_id,
+            lease_key,
+            granted_state: RwLock::new(granted_state),
+            refcount: AtomicUsize::new(1),
+            tombstoned: AtomicBool::new(false),
+            last_used: RwLock::new(Instant::now()),
+        }
+    }
 }

--- a/crates/smb/src/lease.rs
+++ b/crates/smb/src/lease.rs
@@ -14,11 +14,17 @@
 //! drops *and* the slot has been tombstoned, or (b) an explicit eviction
 //! runs (e.g. before `delete` or `rename`).
 
+use crate::connection::connection_info::ConnectionInfo;
+use crate::msg_handler::HandlerReference;
+use crate::resource::ResourceMessageHandle;
 use smb_dtyp::Guid;
-use smb_msg::{FileId, LeaseState};
+use smb_fscc::FileAccessMask;
+use smb_msg::{CreateDisposition, FileId, LeaseState, ShareType};
+use std::sync::Arc;
 use std::sync::RwLock;
-use std::sync::atomic::{AtomicBool, AtomicUsize};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Instant;
+use time::PrimitiveDateTime;
 
 /// A single lease-break notification received from the server, normalized
 /// into a `Copy`-cheap form for fan-out across subscribers.
@@ -57,6 +63,52 @@ pub struct LeaseBreakEvent {
     pub received_at: Instant,
 }
 
+/// Internal handler/conn-info prototype captured at slot-insert time so a
+/// later cache hit can construct a fresh [`crate::ResourceHandle`] sharing
+/// the same FileId without re-issuing Create. Held inside [`LeaseSlot`]
+/// behind an `Arc` so cloning is cheap and stable across hits.
+pub(crate) struct ResourceProto {
+    /// Shared handler chain — `Arc`-backed under the hood, so cloning into
+    /// a new ResourceHandle on hit is just a refcount bump.
+    pub handler: HandlerReference<ResourceMessageHandle>,
+    /// Snapshot of the connection's negotiated info at create time; the
+    /// same instance every resulting ResourceHandle reads from. Cheap to
+    /// clone (Arc).
+    pub conn_info: Arc<ConnectionInfo>,
+    /// Server's reported created time at the moment of the original
+    /// Create. We surface this on cache-hit handles unchanged — the
+    /// HandleCaching lease guarantees no one else changed the file.
+    pub created: PrimitiveDateTime,
+    /// Server's last-modified time at the moment of the original Create,
+    /// surfaced unchanged on cache hits for the same reason as `created`.
+    pub modified: PrimitiveDateTime,
+    /// Share type of the originating Create (Disk / Pipe). Used to
+    /// reconstruct the right `Resource::{File,Directory,Pipe}` variant.
+    pub share_type: ShareType,
+    /// File size at the moment of the original Create. Surfaced on hit;
+    /// the lease covers data state, so this remains accurate as long as
+    /// the lease isn't tombstoned.
+    pub endof_file: u64,
+    /// Whether the original Create returned a directory. Cache hits must
+    /// match the requested kind (`CreateOptions::directory_file()`).
+    pub is_dir: bool,
+    /// Granted access at the moment of the original Create, as expanded
+    /// by the server in the Maximal-Access response context. Surfaced
+    /// unchanged on cache-hit handles so callers see the same `access()`
+    /// before vs. after caching.
+    pub access: FileAccessMask,
+    /// User-requested access mask from `FileCreateArgs::desired_access`
+    /// at original-Create time, *before* server expansion. Cache-hit
+    /// eligibility compares the *new* request against this so that the
+    /// generic-vs-specific bit mismatch (the server expands `generic_*`
+    /// into specific bits when filling Maximal-Access) doesn't cause a
+    /// spurious miss when the caller repeats the same logical request.
+    pub requested_access: FileAccessMask,
+    /// Lease epoch reported by the server at grant time. Stored only for
+    /// diagnostics; the lease lifecycle is keyed on `lease_key`, not epoch.
+    pub epoch_at_grant: u16,
+}
+
 /// A cached, lease-protected open. Owned by the
 /// connection's `lease_table`; multiple [`crate::ResourceHandle`] instances
 /// may share an `Arc<LeaseSlot>` and operate on the same server-side
@@ -69,10 +121,6 @@ pub struct LeaseBreakEvent {
 ///
 /// Until both conditions are met, the FileId stays live on the server and
 /// new Opens against the same path hit the cache for free.
-///
-/// Phase C lays down the type and the insert path; cache hits, deferred
-/// close, and break-driven tombstoning land in later micro-steps of the
-/// same phase.
 pub struct LeaseSlot {
     /// The file path (relative to the share root) the lease was opened
     /// against. Used as the lookup key inside the per-connection table
@@ -104,17 +152,26 @@ pub struct LeaseSlot {
     /// `flush_idle_leases(Duration)` to evict slots whose lease the
     /// server may have silently dropped on its side.
     pub last_used: RwLock<Instant>,
+    /// Reconstruction snapshot (Phase C.3): everything a cache hit needs
+    /// to materialize a fresh `ResourceHandle` without sending Create on
+    /// the wire. `pub(crate)` because it references internal handler
+    /// types; external callers don't need direct access.
+    pub(crate) proto: Arc<ResourceProto>,
 }
 
 impl LeaseSlot {
-    /// Construct a new slot from a successful Create response. Initial
-    /// refcount is `1` (the caller's handle), not tombstoned.
-    pub fn new(
+    /// Construct a new slot from a successful Create response, capturing
+    /// both the lease identity (key/state/file_id) and a [`ResourceProto`]
+    /// snapshot for future cache-hit reconstruction. Initial refcount is
+    /// `1` (the caller's handle that triggered the Create), not tombstoned.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new_with_proto(
         path: String,
         tree_id: u32,
         file_id: FileId,
         lease_key: u128,
         granted_state: LeaseState,
+        proto: Arc<ResourceProto>,
     ) -> Self {
         Self {
             path,
@@ -125,6 +182,107 @@ impl LeaseSlot {
             refcount: AtomicUsize::new(1),
             tombstoned: AtomicBool::new(false),
             last_used: RwLock::new(Instant::now()),
+            proto,
         }
     }
+
+    /// Phase C.3: attempt to satisfy the caller's `args` from this cached
+    /// slot. Returns `true` (with `refcount` already incremented) when the
+    /// caller may skip the wire Create and reuse the slot's `FileId`.
+    /// Returns `false` (no side effects) otherwise.
+    ///
+    /// The bar for a hit is intentionally strict so we never silently mask
+    /// a real semantic difference between requests:
+    /// * Disposition must be `Open` — anything that may overwrite, supersede
+    ///   or create-if-missing has to hit the wire.
+    /// * The slot's lease must still have `HandleCaching` — that's the bit
+    ///   that lets the client treat the FileId as durable across app-level
+    ///   close (MS-SMB2 2.2.13.2.10).
+    /// * The slot must not be tombstoned (no in-flight break revoking it).
+    /// * Directory-vs-file kind must match the caller's expectation.
+    /// * Requested access must be a subset of the slot's granted access.
+    ///
+    /// Note on access: we compare the requested bits as a subset of the
+    /// snapshot's granted bits. This is conservative — a server that
+    /// expanded `generic_read` into specific bits at first Create will
+    /// snapshot the expanded mask; matching the same `generic_read`
+    /// request will pass that subset check.
+    pub(crate) fn try_acquire_for_reuse(
+        &self,
+        requested_access: FileAccessMask,
+        requested_disposition: CreateDisposition,
+        wants_directory: bool,
+    ) -> bool {
+        if requested_disposition != CreateDisposition::Open {
+            return false;
+        }
+        if self.tombstoned.load(Ordering::Acquire) {
+            return false;
+        }
+        if wants_directory != self.proto.is_dir {
+            return false;
+        }
+
+        // HandleCaching is the wire-level promise that lets us defer the
+        // Close. Without it, the server may have already released the
+        // FileId on its side after our last close call.
+        let state = match self.granted_state.read() {
+            Ok(s) => *s,
+            Err(_) => return false,
+        };
+        if !state.handle_caching() {
+            return false;
+        }
+
+        // Access subset check: the *new* request's bits must be a subset
+        // of the bits *the original Create requested*. Comparing against
+        // the server's Maximal-Access response would mis-fire because
+        // the server expands `generic_*` into specific bits, so a
+        // user-level `generic_read` request would look "smaller" than
+        // its own expansion and miss. Tracking `proto.requested_access`
+        // separately keeps the apples-to-apples comparison.
+        let req = u32::from_le_bytes(requested_access.into_bytes());
+        let cached_req = u32::from_le_bytes(self.proto.requested_access.into_bytes());
+        if (req & !cached_req) != 0 {
+            return false;
+        }
+
+        // All gates passed: mark the slot as freshly used and bump the
+        // refcount under Acquire/Release so the deferred-close path in
+        // `Resource::Drop` observes our increment.
+        self.refcount.fetch_add(1, Ordering::AcqRel);
+        if let Ok(mut last) = self.last_used.write() {
+            *last = Instant::now();
+        }
+        true
+    }
+
+    /// Phase C.4: decrement the refcount on close/drop. Returns
+    /// [`SlotReleaseAction::CloseAndEvict`] when this caller was the
+    /// last live reference *and* the slot is tombstoned — at which point
+    /// the caller must send the deferred wire `Close` and remove the
+    /// slot from the per-connection table. In all other cases returns
+    /// [`SlotReleaseAction::KeepCached`] and the slot stays in the
+    /// table for future hits.
+    pub(crate) fn release_one(&self) -> SlotReleaseAction {
+        let prev = self.refcount.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(prev > 0, "lease slot refcount underflow");
+        if prev == 1 && self.tombstoned.load(Ordering::Acquire) {
+            SlotReleaseAction::CloseAndEvict
+        } else {
+            SlotReleaseAction::KeepCached
+        }
+    }
+}
+
+/// Outcome of [`LeaseSlot::release_one`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SlotReleaseAction {
+    /// Slot stays in the cache; either there are still live references
+    /// or the slot has not been tombstoned and can serve future hits.
+    KeepCached,
+    /// Last live reference dropped and the slot is tombstoned — the
+    /// caller is responsible for sending the wire `Close` and removing
+    /// the entry from the connection's `lease_table`.
+    CloseAndEvict,
 }

--- a/crates/smb/src/lib.rs
+++ b/crates/smb/src/lib.rs
@@ -36,8 +36,8 @@ pub use connection::{Connection, ConnectionConfig};
 pub use error::Error;
 pub use lease::LeaseBreakEvent;
 pub use resource::{
-    Directory, File, FileCreateArgs, GetLen, Pipe, PipeRpcConnection, ReadAt, ReadAtChannel,
-    Resource, ResourceHandle, WriteAt, WriteAtChannel,
+    Directory, File, FileCreateArgs, GetLen, LeaseGrant, Pipe, PipeRpcConnection, ReadAt,
+    ReadAtChannel, Resource, ResourceHandle, WriteAt, WriteAtChannel,
 };
 pub use session::Session;
 pub use tree::{DfsRootTreeRef, Tree};

--- a/crates/smb/src/lib.rs
+++ b/crates/smb/src/lib.rs
@@ -25,6 +25,7 @@ pub mod crypto;
 pub mod dialects;
 pub mod docs;
 pub mod error;
+pub mod lease;
 pub mod msg_handler;
 pub mod resource;
 pub mod session;
@@ -33,6 +34,7 @@ pub mod tree;
 pub use client::{Client, ClientConfig, UncPath};
 pub use connection::{Connection, ConnectionConfig};
 pub use error::Error;
+pub use lease::LeaseBreakEvent;
 pub use resource::{
     Directory, File, FileCreateArgs, GetLen, Pipe, PipeRpcConnection, ReadAt, ReadAtChannel,
     Resource, ResourceHandle, WriteAt, WriteAtChannel,

--- a/crates/smb/src/msg_handler.rs
+++ b/crates/smb/src/msg_handler.rs
@@ -102,7 +102,7 @@ impl IncomingMessage {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct MessageForm {
     pub compressed: bool,
     pub encrypted: bool,

--- a/crates/smb/src/resource.rs
+++ b/crates/smb/src/resource.rs
@@ -147,7 +147,6 @@ impl Resource {
             QueryMaximalAccessRequest::default().into(),
             QueryOnDiskIdReq.into(),
         ];
-        let lease_requested = create_args.lease_request.is_some();
         if let Some(lease_req) = create_args.lease_request.as_ref() {
             contexts.push(lease_req.clone().into());
         }
@@ -155,7 +154,7 @@ impl Resource {
         // MS-SMB2 2.2.13: server 只在 RequestedOplockLevel = Lease (0xFF) 时把
         // `RqLs` context 当 lease 处理；任何其他值（含 None）都让 server 静默忽略。
         // 因此 lease 请求必须把 oplock level 同步切到 Lease。
-        let requested_oplock_level = if lease_requested {
+        let requested_oplock_level = if create_args.lease_request.is_some() {
             OplockLevel::Lease
         } else {
             OplockLevel::None
@@ -200,13 +199,13 @@ impl Resource {
 
         // 仅在 client 显式请求 lease 时才尝试解析 RqLs response context；server 未授予
         // (None) 与 client 未请求语义等价 —— 上层调用方都按"无 lease"处理。
-        let lease_granted = if lease_requested {
+        let lease_granted = if create_args.lease_request.is_some() {
             let grant = CreateContextResponseData::first_rqls(&response.create_contexts)
                 .map(LeaseGrant::from_response);
             match &grant {
                 Some(g) => tracing::debug!(
-                    "Lease granted for '{}': key={:#034x}, state={:?}, epoch={}, v2={}",
-                    name, g.key, g.state, g.epoch, g.is_v2
+                    "Lease granted for '{}': key={:#034x}, state={:?}, epoch={}",
+                    name, g.key, g.state, g.epoch
                 ),
                 None => tracing::debug!(
                     "Lease requested for '{}' but server did not grant one",
@@ -335,6 +334,10 @@ make_resource_try_into!(File, Directory, Pipe,);
 /// in a `CreateResponse`. Captures only the fields the client needs to track
 /// the lease lifecycle; Phase B/C will key into [`ResourceHandle::lease_granted`]
 /// when wiring break notifications and the lease_table cache.
+///
+/// `epoch == 0` is valid for either a v1 lease (no epoch field on the wire)
+/// or a v2 lease whose server happens to start at epoch 0. Callers needing
+/// to distinguish should compare against the `RequestLease` variant they sent.
 #[derive(Debug, Clone, Copy)]
 pub struct LeaseGrant {
     /// Client-generated key that identifies this lease.
@@ -342,10 +345,8 @@ pub struct LeaseGrant {
     /// The lease state actually granted by the server (may be a subset of
     /// what was requested).
     pub state: LeaseState,
-    /// Epoch counter for state changes (always 0 for v1 leases).
+    /// Epoch counter for state changes; `0` for v1 leases.
     pub epoch: u16,
-    /// `true` if the response carried a v2 (`RqLsReqv2`) lease, `false` for v1.
-    pub is_v2: bool,
 }
 
 impl LeaseGrant {
@@ -356,13 +357,11 @@ impl LeaseGrant {
                 key: v1.lease_key,
                 state: v1.lease_state,
                 epoch: 0,
-                is_v2: false,
             },
             RequestLease::RqLsReqv2(v2) => Self {
                 key: v2.lease_key,
                 state: v2.lease_state,
                 epoch: v2.epoch,
-                is_v2: true,
             },
         }
     }
@@ -1107,7 +1106,6 @@ mod tests {
         assert!(grant.state.handle_caching());
         assert!(!grant.state.write_caching());
         assert_eq!(grant.epoch, 0, "v1 lease has no epoch field");
-        assert!(!grant.is_v2);
     }
 
     #[test]
@@ -1125,7 +1123,6 @@ mod tests {
         assert!(grant.state.handle_caching());
         assert!(grant.state.write_caching());
         assert_eq!(grant.epoch, 0x1337);
-        assert!(grant.is_v2);
     }
 
     #[test]

--- a/crates/smb/src/resource.rs
+++ b/crates/smb/src/resource.rs
@@ -1077,6 +1077,20 @@ impl ResourceHandle {
         Ok(())
     }
 
+    /// Phase C.5: pub(crate) entry point so the lease-eviction path in
+    /// [`crate::Client::flush_eviction`] can send the deferred wire
+    /// `Close` against a slot whose owning [`ResourceHandle`] is already
+    /// gone (refcount was zero at evict time). The handler is pulled
+    /// from `LeaseSlot::proto`, so the close goes through the same
+    /// tree+session as the original Create.
+    #[maybe_async]
+    pub(crate) async fn send_close_external(
+        file_id: FileId,
+        handler: &HandlerReference<ResourceMessageHandle>,
+    ) -> crate::Result<()> {
+        Self::send_close(file_id, handler).await
+    }
+
     /// Closes the resource.
     /// The resource may not be used after calling this method.
     ///

--- a/crates/smb/src/resource.rs
+++ b/crates/smb/src/resource.rs
@@ -12,6 +12,7 @@ use time::PrimitiveDateTime;
 use crate::{
     Error,
     connection::connection_info::ConnectionInfo,
+    lease::{LeaseSlot, ResourceProto, SlotReleaseAction},
     msg_handler::{
         AsyncMessageIds, HandlerReference, IncomingMessage, MessageHandler, OutgoingMessage,
         ReceiveOptions, SendMessageResult,
@@ -217,7 +218,10 @@ impl Resource {
             None
         };
 
-        // Common information is held in the handle object.
+        // Common information is held in the handle object. `lease_slot`
+        // defaults to None; if a lease was granted and the higher-level
+        // client opts in, [`Client::_create_file`] will attach a slot via
+        // [`Resource::attach_lease_slot`] after this function returns.
         let handle = ResourceHandle {
             name: name.to_string(),
             handler: ResourceMessageHandle::new(upstream),
@@ -227,6 +231,7 @@ impl Resource {
             modified: response.last_write_time.date_time(),
             access,
             lease_granted,
+            lease_slot: None,
             share_type,
             conn_info: conn_info.clone(),
         };
@@ -268,6 +273,119 @@ impl Resource {
             Resource::Directory(d) => Some(d.handle()),
             Resource::Pipe(p) => Some(p.handle()),
         }
+    }
+
+    /// Mutable counterpart to [`Resource::handle`]. Phase C uses this
+    /// from [`Client::_create_file`] to attach a fresh lease slot to a
+    /// resource that was just opened on the wire — once attached, the
+    /// resource's `close()` and `Drop` participate in deferred-close.
+    pub(crate) fn handle_mut(&mut self) -> Option<&mut ResourceHandle> {
+        match self {
+            Resource::File(f) => Some(&mut f.handle),
+            Resource::Directory(d) => Some(&mut d.handle),
+            Resource::Pipe(p) => Some(&mut p.handle),
+        }
+    }
+
+    /// Phase C.3: install a lease slot on a freshly-created resource so
+    /// its close/Drop will go through the deferred-close path. Called by
+    /// [`Client::_create_file`] right after slot insertion in the
+    /// connection's `lease_table`. Idempotent — overwriting an existing
+    /// slot would be a logic bug (only the original Create attaches one),
+    /// so we don't guard against it.
+    pub(crate) fn attach_lease_slot(&mut self, slot: Arc<LeaseSlot>) {
+        if let Some(h) = self.handle_mut() {
+            h.lease_slot = Some(slot);
+        }
+    }
+
+    /// Phase C.3: materialize a cache-hit resource from an existing
+    /// `LeaseSlot`. Skips the wire `Create` entirely — the returned
+    /// resource reuses the slot's `FileId`, handler chain, and creation
+    /// metadata. The slot's refcount is *not* incremented here; the
+    /// caller (`Client::_create_file`) must have already called
+    /// [`LeaseSlot::try_acquire_for_reuse`] which performs the bump
+    /// atomically with the eligibility check.
+    pub(crate) fn reuse_from_slot(slot: Arc<LeaseSlot>) -> Resource {
+        let proto = slot.proto.clone();
+        let granted_state = slot
+            .granted_state
+            .read()
+            .map(|s| *s)
+            .unwrap_or_else(|p| *p.into_inner());
+
+        let handle = ResourceHandle {
+            name: slot.path.clone(),
+            handler: proto.handler.clone(),
+            open: AtomicBool::new(true),
+            _file_id: slot.file_id,
+            created: proto.created,
+            modified: proto.modified,
+            access: proto.access,
+            lease_granted: Some(LeaseGrant {
+                key: slot.lease_key,
+                state: granted_state,
+                epoch: proto.epoch_at_grant,
+            }),
+            lease_slot: Some(slot.clone()),
+            share_type: proto.share_type,
+            conn_info: proto.conn_info.clone(),
+        };
+
+        if proto.is_dir {
+            Resource::Directory(Directory::new(handle))
+        } else {
+            match proto.share_type {
+                ShareType::Disk => Resource::File(File::new(handle, proto.endof_file)),
+                ShareType::Pipe => Resource::Pipe(Pipe::new(handle)),
+                ShareType::Print => {
+                    // Cache-hit on a Print share is impossible: print
+                    // creates always use `CreateDisposition::Create`,
+                    // which `try_acquire_for_reuse` rejects. Falling
+                    // back to a File wrapper here keeps the type system
+                    // happy without introducing a dead variant.
+                    Resource::File(File::new(handle, proto.endof_file))
+                }
+            }
+        }
+    }
+
+    /// Build a [`ResourceProto`] snapshot from a freshly-created resource
+    /// and an `Upstream` reference. Phase C.1's slot-insert path now
+    /// captures full reconstruction data here instead of the partial
+    /// (file_id, lease_key, state) tuple it carried originally. Returns
+    /// `None` only when the resource has no handle (shouldn't happen for
+    /// successful creates today).
+    ///
+    /// `requested_access` must be the user-facing
+    /// [`FileCreateArgs::desired_access`] from the originating Create
+    /// (pre-server-expansion). Cache-hit eligibility compares the new
+    /// caller's request against this, so passing the server-expanded
+    /// mask here would cause spurious misses for `generic_*` requests.
+    pub(crate) fn build_lease_proto(
+        &self,
+        upstream: &Upstream,
+        requested_access: FileAccessMask,
+    ) -> Option<Arc<ResourceProto>> {
+        let h = self.handle()?;
+        let endof_file = match self {
+            Resource::File(f) => f.end_of_file(),
+            _ => 0,
+        };
+        let is_dir = matches!(self, Resource::Directory(_));
+        let epoch_at_grant = h.lease_granted.map(|g| g.epoch).unwrap_or(0);
+        Some(Arc::new(ResourceProto {
+            handler: ResourceMessageHandle::new(upstream),
+            conn_info: h.conn_info.clone(),
+            created: h.created,
+            modified: h.modified,
+            share_type: h.share_type,
+            endof_file,
+            is_dir,
+            access: h.access,
+            requested_access,
+            epoch_at_grant,
+        }))
     }
 
     pub fn as_dir(&self) -> Option<&Directory> {
@@ -403,6 +521,13 @@ pub struct ResourceHandle {
     /// `Some` and the server replied with an `RqLs` response context.
     /// `None` when no lease was requested or the server didn't grant one.
     lease_granted: Option<LeaseGrant>,
+
+    /// Phase C: when this handle is backed by a cached lease slot, close()
+    /// and Drop release a refcount on the slot instead of sending a wire
+    /// `Close`. The real `Close` is deferred until the slot is tombstoned
+    /// *and* its refcount reaches zero. `None` for opens that didn't
+    /// participate in the lease cache.
+    lease_slot: Option<Arc<LeaseSlot>>,
 
     conn_info: Arc<ConnectionInfo>,
 }
@@ -955,12 +1080,51 @@ impl ResourceHandle {
     /// Closes the resource.
     /// The resource may not be used after calling this method.
     ///
+    /// # Phase C deferred-close
+    ///
+    /// When this handle is backed by a [`LeaseSlot`] (i.e. the original
+    /// Create or a cache-hit reopen attached one), the wire `Close` is
+    /// suppressed: we just flip `open = false` locally and release one
+    /// refcount on the slot. The slot's FileId stays valid on the
+    /// server, available for the next reopen on the same path.
+    ///
+    /// The real `Close` is sent only when [`LeaseSlot::release_one`]
+    /// reports [`SlotReleaseAction::CloseAndEvict`] — i.e. *this* close
+    /// dropped the refcount to zero *and* the slot has been tombstoned
+    /// (server break or explicit eviction).
+    ///
     /// # Returns
     /// A `Result` indicating success or failure.
     #[tracing::instrument(level = "debug", skip_all, fields(name = %self.name))]
     pub async fn close(&self) -> crate::Result<()> {
         if !self.open.swap(false, std::sync::atomic::Ordering::Relaxed) {
             return Err(Error::InvalidState("Resource is already closed".into()));
+        }
+
+        if let Some(slot) = self.lease_slot.as_ref() {
+            match slot.release_one() {
+                SlotReleaseAction::KeepCached => {
+                    tracing::debug!(
+                        path = %slot.path,
+                        file_id = ?self._file_id,
+                        "Deferred close: lease slot still cached",
+                    );
+                    return Ok(());
+                }
+                SlotReleaseAction::CloseAndEvict => {
+                    tracing::debug!(
+                        path = %slot.path,
+                        file_id = ?self._file_id,
+                        "Lease slot evicted; sending deferred Close on the wire",
+                    );
+                    // Fall through to the regular send_close path below.
+                    // The connection-level lease_table cleanup happens on
+                    // the next sweep (Phase C.5 flush_idle_leases) or on
+                    // explicit Client::evict_lease — keeping the entry
+                    // around briefly is harmless because tombstoned slots
+                    // are not eligible for cache hits.
+                }
+            }
         }
 
         tracing::debug!(file_id = ?self._file_id, "Closing handle");
@@ -1029,12 +1193,15 @@ impl ResourceHandle {
     }
 }
 
-struct ResourceMessageHandle {
+// `pub(crate)` so [`crate::lease::ResourceProto`] can hold a `HandlerReference`
+// to it across the cache-hit reconstruction path. The type itself remains
+// invisible to external callers — they only interact through `Resource`.
+pub(crate) struct ResourceMessageHandle {
     upstream: Upstream,
 }
 
 impl ResourceMessageHandle {
-    fn new(upstream: &Upstream) -> HandlerReference<ResourceMessageHandle> {
+    pub(crate) fn new(upstream: &Upstream) -> HandlerReference<ResourceMessageHandle> {
         HandlerReference::new(ResourceMessageHandle {
             upstream: upstream.clone(),
         })
@@ -1083,6 +1250,31 @@ impl Drop for ResourceHandle {
         if !self.open.swap(false, std::sync::atomic::Ordering::Relaxed) {
             // already closed, no problem
             return;
+        }
+
+        // Phase C: if a lease slot is in play, decrement its refcount and
+        // only send the wire `Close` when this drop made the slot
+        // releasable (refcount=0 AND tombstoned). Otherwise the FileId
+        // stays alive for the next cache hit.
+        if let Some(slot) = self.lease_slot.as_ref() {
+            match slot.release_one() {
+                SlotReleaseAction::KeepCached => {
+                    tracing::debug!(
+                        path = %slot.path,
+                        file_id = ?self._file_id,
+                        "Drop: lease slot retained (not tombstoned or refs remain)",
+                    );
+                    return;
+                }
+                SlotReleaseAction::CloseAndEvict => {
+                    tracing::debug!(
+                        path = %slot.path,
+                        file_id = ?self._file_id,
+                        "Drop: lease slot evicted; scheduling wire Close",
+                    );
+                    // Fall through to the legacy spawn-Close branch below.
+                }
+            }
         }
 
         let file_id = self._file_id;

--- a/crates/smb/src/resource.rs
+++ b/crates/smb/src/resource.rs
@@ -37,6 +37,12 @@ pub struct FileCreateArgs {
     pub attributes: FileAttributes,
     pub options: CreateOptions,
     pub desired_access: FileAccessMask,
+    /// Optional lease request context (`RqLs`) attached to the CREATE.
+    /// Set to `None` (default) to preserve the legacy "no lease" behavior.
+    /// Set to `Some(RequestLease::RqLsReqv2(...))` on SMB 3.x to ask the
+    /// server for read/handle/write caching; the granted state is reported
+    /// back via [`ResourceHandle::lease_granted`].
+    pub lease_request: Option<RequestLease>,
 }
 
 impl FileCreateArgs {
@@ -46,6 +52,7 @@ impl FileCreateArgs {
             attributes: FileAttributes::new(),
             options: CreateOptions::new(),
             desired_access: access,
+            ..Default::default()
         }
     }
 
@@ -57,6 +64,7 @@ impl FileCreateArgs {
             attributes,
             options,
             desired_access: FileAccessMask::new().with_generic_all(true),
+            ..Default::default()
         }
     }
 
@@ -69,6 +77,7 @@ impl FileCreateArgs {
             attributes,
             options,
             desired_access: FileAccessMask::new().with_generic_all(true),
+            ..Default::default()
         }
     }
 
@@ -81,7 +90,16 @@ impl FileCreateArgs {
             desired_access: FileAccessMask::new()
                 .with_generic_read(true)
                 .with_generic_write(true),
+            ..Default::default()
         }
+    }
+
+    /// Attach a lease (`RqLs`) request to a create. Returns `self` for builder-style chaining.
+    /// Caller must ensure the SMB connection negotiated the leasing capability;
+    /// servers that don't support leasing will simply ignore the context.
+    pub fn with_lease(mut self, lease: RequestLease) -> Self {
+        self.lease_request = Some(lease);
+        self
     }
 }
 
@@ -123,9 +141,29 @@ impl Resource {
             ));
         }
 
+        // 标准 create context 列表：MxAc + QFid 始终发送；lease (RqLs) 仅在调用方显式
+        // 请求时附加，保持现有非-lease 调用方零行为变化。
+        let mut contexts: Vec<CreateContextRequest> = vec![
+            QueryMaximalAccessRequest::default().into(),
+            QueryOnDiskIdReq.into(),
+        ];
+        let lease_requested = create_args.lease_request.is_some();
+        if let Some(lease_req) = create_args.lease_request.as_ref() {
+            contexts.push(lease_req.clone().into());
+        }
+
+        // MS-SMB2 2.2.13: server 只在 RequestedOplockLevel = Lease (0xFF) 时把
+        // `RqLs` context 当 lease 处理；任何其他值（含 None）都让 server 静默忽略。
+        // 因此 lease 请求必须把 oplock level 同步切到 Lease。
+        let requested_oplock_level = if lease_requested {
+            OplockLevel::Lease
+        } else {
+            OplockLevel::None
+        };
+
         let mut msg = OutgoingMessage::new(
             CreateRequest {
-                requested_oplock_level: OplockLevel::None,
+                requested_oplock_level,
                 impersonation_level: ImpersonationLevel::Impersonation,
                 desired_access: create_args.desired_access,
                 file_attributes: create_args.attributes,
@@ -133,11 +171,7 @@ impl Resource {
                 create_disposition: create_args.disposition,
                 create_options: create_args.options,
                 name: name.into(),
-                contexts: vec![
-                    QueryMaximalAccessRequest::default().into(),
-                    QueryOnDiskIdReq.into(),
-                ]
-                .into(),
+                contexts: contexts.into(),
             }
             .into(),
         );
@@ -164,6 +198,26 @@ impl Resource {
                 }
             );
 
+        // 仅在 client 显式请求 lease 时才尝试解析 RqLs response context；server 未授予
+        // (None) 与 client 未请求语义等价 —— 上层调用方都按"无 lease"处理。
+        let lease_granted = if lease_requested {
+            let grant = CreateContextResponseData::first_rqls(&response.create_contexts)
+                .map(LeaseGrant::from_response);
+            match &grant {
+                Some(g) => tracing::debug!(
+                    "Lease granted for '{}': key={:#034x}, state={:?}, epoch={}, v2={}",
+                    name, g.key, g.state, g.epoch, g.is_v2
+                ),
+                None => tracing::debug!(
+                    "Lease requested for '{}' but server did not grant one",
+                    name
+                ),
+            }
+            grant
+        } else {
+            None
+        };
+
         // Common information is held in the handle object.
         let handle = ResourceHandle {
             name: name.to_string(),
@@ -173,6 +227,7 @@ impl Resource {
             created: response.creation_time.date_time(),
             modified: response.last_write_time.date_time(),
             access,
+            lease_granted,
             share_type,
             conn_info: conn_info.clone(),
         };
@@ -276,6 +331,43 @@ impl TryInto<$t> for Resource {
 
 make_resource_try_into!(File, Directory, Pipe,);
 
+/// Information about a granted lease, extracted from the `RqLs` create-context
+/// in a `CreateResponse`. Captures only the fields the client needs to track
+/// the lease lifecycle; Phase B/C will key into [`ResourceHandle::lease_granted`]
+/// when wiring break notifications and the lease_table cache.
+#[derive(Debug, Clone, Copy)]
+pub struct LeaseGrant {
+    /// Client-generated key that identifies this lease.
+    pub key: u128,
+    /// The lease state actually granted by the server (may be a subset of
+    /// what was requested).
+    pub state: LeaseState,
+    /// Epoch counter for state changes (always 0 for v1 leases).
+    pub epoch: u16,
+    /// `true` if the response carried a v2 (`RqLsReqv2`) lease, `false` for v1.
+    pub is_v2: bool,
+}
+
+impl LeaseGrant {
+    /// Extract a [`LeaseGrant`] from a parsed `RqLs` response context.
+    pub(crate) fn from_response(r: &RequestLease) -> Self {
+        match r {
+            RequestLease::RqLsReqv1(v1) => Self {
+                key: v1.lease_key,
+                state: v1.lease_state,
+                epoch: 0,
+                is_v2: false,
+            },
+            RequestLease::RqLsReqv2(v2) => Self {
+                key: v2.lease_key,
+                state: v2.lease_state,
+                epoch: v2.epoch,
+                is_v2: true,
+            },
+        }
+    }
+}
+
 /// Holds the common information for an opened SMB resource.
 pub struct ResourceHandle {
     name: String,
@@ -293,6 +385,11 @@ pub struct ResourceHandle {
     share_type: ShareType,
 
     access: FileAccessMask,
+
+    /// Granted lease for this open, when [`FileCreateArgs::lease_request`] was
+    /// `Some` and the server replied with an `RqLs` response context.
+    /// `None` when no lease was requested or the server didn't grant one.
+    lease_granted: Option<LeaseGrant>,
 
     conn_info: Arc<ConnectionInfo>,
 }
@@ -312,6 +409,17 @@ impl ResourceHandle {
     /// Returns the last modified time of the resource.
     pub fn modified(&self) -> PrimitiveDateTime {
         self.modified
+    }
+
+    /// Returns the lease granted for this open, if any.
+    ///
+    /// Returns `None` when no lease was requested via
+    /// [`FileCreateArgs::lease_request`], or when the server did not respond
+    /// with an `RqLs` create context. Callers should treat `None` as
+    /// "the open has no caching guarantees" and fall back to per-operation
+    /// network round-trips.
+    pub fn lease_granted(&self) -> Option<LeaseGrant> {
+        self.lease_granted
     }
 
     /// Returns the current share type of the resource. See [ShareType] for more details.
@@ -964,5 +1072,82 @@ impl Drop for ResourceHandle {
                 }
             }
         });
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    // `use maybe_async::*;` at the file top brings a `test` macro into our parent
+    // scope, which conflicts with the standard `#[test]` attribute. Pull the
+    // standard one in explicitly so attribute resolution is unambiguous.
+    #[allow(unused_imports)]
+    use core::prelude::v1::test;
+
+    use super::{FileCreateArgs, LeaseGrant};
+    use smb_fscc::FileAccessMask;
+    use smb_msg::{LeaseFlags, LeaseState, RequestLease, RequestLeaseV1, RequestLeaseV2};
+
+    fn make_state(read: bool, handle: bool, write: bool) -> LeaseState {
+        LeaseState::new()
+            .with_read_caching(read)
+            .with_handle_caching(handle)
+            .with_write_caching(write)
+    }
+
+    #[test]
+    fn lease_grant_from_v1() {
+        let v1 = RequestLeaseV1 {
+            lease_key: 0x1122_3344_5566_7788_99AA_BBCC_DDEE_FF00_u128,
+            lease_state: make_state(true, true, false),
+        };
+        let grant = LeaseGrant::from_response(&RequestLease::RqLsReqv1(v1));
+        assert_eq!(grant.key, 0x1122_3344_5566_7788_99AA_BBCC_DDEE_FF00_u128);
+        assert!(grant.state.read_caching());
+        assert!(grant.state.handle_caching());
+        assert!(!grant.state.write_caching());
+        assert_eq!(grant.epoch, 0, "v1 lease has no epoch field");
+        assert!(!grant.is_v2);
+    }
+
+    #[test]
+    fn lease_grant_from_v2() {
+        let v2 = RequestLeaseV2 {
+            lease_key: 0xDEAD_BEEF_CAFE_BABE_1234_5678_9ABC_DEF0_u128,
+            lease_state: make_state(true, true, true),
+            lease_flags: LeaseFlags::new().with_parent_lease_key_set(true),
+            parent_lease_key: 0x0EDC_BA98_7654_3210_FEDC_BA98_7654_3210_u128,
+            epoch: 0x1337,
+        };
+        let grant = LeaseGrant::from_response(&RequestLease::RqLsReqv2(v2));
+        assert_eq!(grant.key, 0xDEAD_BEEF_CAFE_BABE_1234_5678_9ABC_DEF0_u128);
+        assert!(grant.state.read_caching());
+        assert!(grant.state.handle_caching());
+        assert!(grant.state.write_caching());
+        assert_eq!(grant.epoch, 0x1337);
+        assert!(grant.is_v2);
+    }
+
+    #[test]
+    fn file_create_args_with_lease_builder() {
+        let args = FileCreateArgs::make_open_existing(FileAccessMask::new().with_generic_read(true))
+            .with_lease(RequestLease::RqLsReqv2(RequestLeaseV2 {
+                lease_key: 1,
+                lease_state: make_state(true, true, false),
+                lease_flags: LeaseFlags::new(),
+                parent_lease_key: 0,
+                epoch: 0,
+            }));
+        assert!(args.lease_request.is_some(), "with_lease should populate the field");
+        assert!(matches!(
+            args.lease_request.as_ref().unwrap(),
+            RequestLease::RqLsReqv2(_)
+        ));
+    }
+
+    #[test]
+    fn file_create_args_default_has_no_lease() {
+        let args = FileCreateArgs::default();
+        assert!(args.lease_request.is_none(), "default must not request a lease");
     }
 }

--- a/crates/smb/src/resource.rs
+++ b/crates/smb/src/resource.rs
@@ -256,6 +256,20 @@ impl Resource {
         }
     }
 
+    /// Borrow the underlying [`ResourceHandle`] regardless of resource
+    /// kind. Convenience for callers that need handle-level metadata
+    /// (`name`, `lease_granted`, `raw_file_id`) without first matching
+    /// the variant. Returns `None` for variants that don't have a handle
+    /// surface — currently none, but kept as `Option` for forward
+    /// compatibility.
+    pub fn handle(&self) -> Option<&ResourceHandle> {
+        match self {
+            Resource::File(f) => Some(f.handle()),
+            Resource::Directory(d) => Some(d.handle()),
+            Resource::Pipe(p) => Some(p.handle()),
+        }
+    }
+
     pub fn as_dir(&self) -> Option<&Directory> {
         match self {
             Resource::Directory(d) => Some(d),
@@ -419,6 +433,16 @@ impl ResourceHandle {
     /// network round-trips.
     pub fn lease_granted(&self) -> Option<LeaseGrant> {
         self.lease_granted
+    }
+
+    /// Returns the server-assigned `FileId` for this open, *without* the
+    /// "is-open" sanity check. Exposed for the lease-cache (Phase C):
+    /// `Client::create_file` snapshots the FileId at Create time and
+    /// installs it into the connection's `lease_table` so subsequent
+    /// cache hits can reuse the same id. Callers should not use this
+    /// FileId for direct I/O — go through the resource's typed methods.
+    pub fn raw_file_id(&self) -> FileId {
+        self._file_id
     }
 
     /// Returns the current share type of the resource. See [ShareType] for more details.

--- a/crates/smb/src/resource/file.rs
+++ b/crates/smb/src/resource/file.rs
@@ -19,7 +19,10 @@ use std::ops::{Deref, DerefMut};
 /// You may not directly create this struct. Instead, use the [Tree::create][crate::tree::Tree::create] method to gain
 /// a proper handle against the server in the shape of a [Resource], that can be then converted to a [File].
 pub struct File {
-    handle: ResourceHandle,
+    // `pub(crate)` so [`crate::resource::Resource::handle_mut`] can take a
+    // mutable borrow during Phase C lease-slot attachment. External callers
+    // still go through [`File::handle()`].
+    pub(crate) handle: ResourceHandle,
 
     #[cfg(not(feature = "async"))]
     pos: u64,
@@ -40,6 +43,14 @@ impl File {
             #[cfg(not(feature = "async"))]
             dirty: false,
         }
+    }
+
+    /// Returns the server-reported size at the moment the file was
+    /// opened. Used by the Phase C lease cache to snapshot the file size
+    /// in [`crate::lease::ResourceProto`] so cache-hit reopens can
+    /// surface the same size without an extra QueryInfo RT.
+    pub(crate) fn end_of_file(&self) -> u64 {
+        self.end_of_file
     }
 
     /// Returns the access mask of the file,

--- a/crates/smb/src/resource/pipe.rs
+++ b/crates/smb/src/resource/pipe.rs
@@ -6,7 +6,9 @@ use maybe_async::*;
 use smb_msg::{IoctlBuffer, PipeTransceiveRequest, ReadRequest, WriteRequest};
 use smb_rpc::{SmbRpcError, interface::*, ndr64::NDR64_SYNTAX_ID, pdu::*};
 pub struct Pipe {
-    handle: ResourceHandle,
+    // `pub(crate)` so [`crate::resource::Resource::handle_mut`] can take a
+    // mutable borrow during Phase C lease-slot attachment.
+    pub(crate) handle: ResourceHandle,
 }
 
 #[maybe_async(AFIT)]

--- a/crates/smb/src/session/channel.rs
+++ b/crates/smb/src/session/channel.rs
@@ -46,6 +46,20 @@ impl Channel {
     pub fn channel_id(&self) -> u32 {
         self.channel_id
     }
+
+    /// Returns `true` when the session permits unsigned messages.
+    ///
+    /// Mirrors the check used inside [`ChannelMessageHandler::sendo`]: a
+    /// session enforces signing iff `allow_unsigned()` is `false` after
+    /// it reaches `is_ready()`. Exposed publicly for callers that build
+    /// SMB2 compound chains (P2.b) and need to set the `signed` flag on
+    /// each chained header before going through the worker directly.
+    #[maybe_async]
+    pub async fn allow_unsigned(&self) -> crate::Result<bool> {
+        let state = self.handler.session_state.read().await?;
+        let session = state.session.read().await?;
+        session.allow_unsigned()
+    }
 }
 
 /// Message handler a specific channel.

--- a/crates/smb/src/tree.rs
+++ b/crates/smb/src/tree.rs
@@ -199,6 +199,13 @@ impl Tree {
         Ok(info.share_flags.dfs_root() && info.share_flags.dfs())
     }
 
+    /// Returns the SMB-assigned tree id for this connected share.
+    /// Used by the lease cache (Phase C) so cache hits can match opens
+    /// against the same tree the original Create was issued on.
+    pub fn tree_id(&self) -> u32 {
+        self.handler.tree_id.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
     pub fn as_dfs_tree(&self) -> crate::Result<DfsRootTreeRef<'_>> {
         if !self.is_dfs_root()? {
             return Err(Error::InvalidState("Tree is not a DFS tree".to_string()));

--- a/crates/smb/src/tree.rs
+++ b/crates/smb/src/tree.rs
@@ -154,6 +154,7 @@ impl Tree {
                 options: CreateOptions::new(),
                 desired_access,
                 attributes: FileAttributes::new(),
+                ..Default::default()
             },
         )
         .await
@@ -175,6 +176,7 @@ impl Tree {
                 options: CreateOptions::new().with_directory_file(true),
                 desired_access,
                 attributes: FileAttributes::new().with_directory(true),
+                ..Default::default()
             },
         )
         .await

--- a/crates/smb/src/tree.rs
+++ b/crates/smb/src/tree.rs
@@ -206,6 +206,15 @@ impl Tree {
         self.handler.tree_id.load(std::sync::atomic::Ordering::Relaxed)
     }
 
+    /// Borrow the tree's underlying `Upstream` handler reference.
+    /// Phase C uses this from [`crate::resource::Resource::build_lease_proto`]
+    /// so the lease cache can construct a `ResourceMessageHandle` against
+    /// the same tree the Create was issued on. `pub(crate)` because the
+    /// `HandlerReference` type is internal.
+    pub(crate) fn handler_ref(&self) -> &HandlerReference<TreeMessageHandler> {
+        &self.handler
+    }
+
     pub fn as_dfs_tree(&self) -> crate::Result<DfsRootTreeRef<'_>> {
         if !self.is_dfs_root()? {
             return Err(Error::InvalidState("Tree is not a DFS tree".to_string()));

--- a/crates/smb/tests/common.rs
+++ b/crates/smb/tests/common.rs
@@ -10,6 +10,10 @@ impl TestEnv {
     pub const DEFAULT_USER: &'static str = "LocalAdmin";
     pub const PASSWORD: &'static str = "SMB_RUST_TESTS_PASSWORD";
     pub const DEFAULT_PASSWORD: &'static str = "123456";
+    /// Optional override for the share name used by integration tests
+    /// (e.g. when pointing at a real lease-capable server with a non-default
+    /// share). Falls back to [`TestConstants::DEFAULT_SHARE`] when unset.
+    pub const SHARE: &'static str = "SMB_RUST_TESTS_SHARE";
 
     pub const GUEST_USER: &'static str = "/GUEST";
     pub const GUEST_PASSWORD: &'static str = "";
@@ -20,6 +24,12 @@ pub struct TestConstants;
 impl TestConstants {
     pub const DEFAULT_SHARE: &'static str = "MyShare";
     pub const PUBLIC_GUEST_SHARE: &'static str = "PublicShare";
+}
+
+/// Reads the share name from `SMB_RUST_TESTS_SHARE`, falling back to
+/// [`TestConstants::DEFAULT_SHARE`] when unset.
+pub fn smb_tests_share() -> String {
+    var(TestEnv::SHARE).unwrap_or_else(|_| TestConstants::DEFAULT_SHARE.to_string())
 }
 
 pub fn default_connection_config() -> ConnectionConfig {

--- a/crates/smb/tests/lease.rs
+++ b/crates/smb/tests/lease.rs
@@ -241,3 +241,149 @@ async fn test_lease_break_notify_fanned_out() -> smb::Result<()> {
     file_a.close().await?;
     Ok(())
 }
+
+/// Phase C.1 (cache table insert):
+///
+/// When `Client::create_file` succeeds with a granted lease, the
+/// connection's `lease_table` must hold an entry keyed by the share-
+/// relative path with a refcount of 1 and `tombstoned == false`. This
+/// is the simplest building block of Phase C — cache hits (C.3),
+/// break-driven tombstoning (C.2), and deferred close (C.4) all build
+/// on this insertion path.
+#[test_log::test(maybe_async::test(
+    not(feature = "async"),
+    async(feature = "async", tokio::test(flavor = "current_thread"))
+))]
+#[serial]
+async fn test_lease_slot_inserted_on_create() -> smb::Result<()> {
+    let share = smb_tests_share();
+    let (client, share_path) = make_server_connection(&share, None).await?;
+    let conn = client.get_connection(share_path.server()).await?;
+    let info = conn.conn_info().expect("connection negotiated");
+    if !info.negotiation.caps.leasing() {
+        tracing::warn!("Server lacks caps.leasing(); skipping C.1 cache-insert test.");
+        return Ok(());
+    }
+
+    // Baseline: cache must start empty for this fresh connection.
+    let baseline = conn.lease_slot_count().await?;
+
+    let path_rel = "lease_phase_c1_insert.txt";
+    let args = FileCreateArgs::make_overwrite(Default::default(), Default::default())
+        .with_lease(make_lease_request());
+    let file = client
+        .create_file(&share_path.with_path(path_rel), &args)
+        .await?
+        .into_file()
+        .expect("Resource must be a file");
+
+    let grant = file
+        .handle()
+        .lease_granted()
+        .expect("server with caps.leasing() must issue a grant");
+
+    // A slot should now exist for our path.
+    assert_eq!(
+        conn.lease_slot_count().await?,
+        baseline + 1,
+        "Create with lease must add one entry to the per-connection lease_table",
+    );
+    let slot = conn
+        .peek_lease_slot(path_rel)
+        .await?
+        .expect("slot must be reachable by path");
+    assert_eq!(slot.lease_key, grant.key, "slot's lease_key must echo the grant");
+    assert_eq!(
+        slot.refcount.load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "initial refcount is the caller's handle",
+    );
+    assert!(
+        !slot.tombstoned.load(std::sync::atomic::Ordering::Relaxed),
+        "fresh slot must not be tombstoned",
+    );
+
+    file.set_info(FileDispositionInformation::default()).await?;
+    file.close().await?;
+    Ok(())
+}
+
+/// Phase C.2 (break-driven tombstone):
+///
+/// Client A opens with HandleCaching; client B opens the same path with
+/// OverwriteIf. Server sends a `LeaseBreakNotify` to A. The per-connection
+/// break-listener spawned during `_negotiate` consumes the event from
+/// `lease_event_tx` and tombstones the matching slot in `lease_table`.
+/// This test polls the slot until tombstoned (or times out) — no event
+/// subscription needed, the test only inspects cache state.
+#[test_log::test(maybe_async::test(
+    not(feature = "async"),
+    async(feature = "async", tokio::test(flavor = "current_thread"))
+))]
+#[serial]
+async fn test_lease_slot_tombstoned_on_break() -> smb::Result<()> {
+    let share = smb_tests_share();
+
+    let (client_a, share_path_a) = make_server_connection(&share, None).await?;
+    let conn_a = client_a.get_connection(share_path_a.server()).await?;
+    let info = conn_a.conn_info().expect("connection negotiated");
+    if !info.negotiation.caps.leasing() {
+        tracing::warn!("Server lacks caps.leasing(); skipping C.2 tombstone test.");
+        return Ok(());
+    }
+
+    let path_rel = "lease_phase_c2_tombstone.txt";
+    let args_a = FileCreateArgs::make_overwrite(Default::default(), Default::default())
+        .with_lease(make_lease_request());
+    let file_a = client_a
+        .create_file(&share_path_a.with_path(path_rel), &args_a)
+        .await?
+        .into_file()
+        .expect("Resource must be a file");
+
+    let slot = conn_a
+        .peek_lease_slot(path_rel)
+        .await?
+        .expect("slot must exist after Create with grant");
+    assert!(
+        !slot.tombstoned.load(std::sync::atomic::Ordering::Acquire),
+        "slot must start un-tombstoned",
+    );
+
+    // Provoke a break from a second client.
+    let (client_b, share_path_b) = make_server_connection(&share, None).await?;
+    let file_b = client_b
+        .create_file(
+            &share_path_b.with_path(path_rel),
+            &FileCreateArgs::make_overwrite(Default::default(), Default::default()),
+        )
+        .await?
+        .into_file()
+        .expect("Resource must be a file");
+
+    // Poll the slot's tombstoned flag with a bounded wait. The listener
+    // task runs on the same tokio runtime; the event flows
+    //   server -> worker -> notify channel -> handle_lease_break
+    //   -> broadcast tx -> listener rx -> apply_lease_break
+    //   -> slot.tombstoned.store(true).
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while !slot.tombstoned.load(std::sync::atomic::Ordering::Acquire) {
+        if std::time::Instant::now() > deadline {
+            panic!("slot was not tombstoned within 10s of B's conflicting open");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    tracing::info!(
+        "Slot tombstoned: granted_state now {:?}",
+        *slot.granted_state.read().expect("rwlock not poisoned"),
+    );
+
+    // Cleanup.
+    drop(file_b);
+    file_a
+        .set_info(FileDispositionInformation::default())
+        .await?;
+    file_a.close().await?;
+    Ok(())
+}

--- a/crates/smb/tests/lease.rs
+++ b/crates/smb/tests/lease.rs
@@ -387,3 +387,110 @@ async fn test_lease_slot_tombstoned_on_break() -> smb::Result<()> {
     file_a.close().await?;
     Ok(())
 }
+
+/// Phase C.3+C.4 (cache hit + deferred close):
+///
+/// Open a file with a HandleCaching lease, close it, then reopen the same
+/// path with the same lease request. The second open must hit the cache:
+///   * No new FileId issued — the second handle reuses the first FileId.
+///   * The connection's lease_table still has the entry (refcount goes
+///     to 1 on the second open, never to 0 with tombstoned=false).
+///   * The slot's `last_used` advances on hit.
+///
+/// This is the first phase that actually saves network RTs. Subsequent
+/// opens against the same path are pure local table lookups.
+#[test_log::test(maybe_async::test(
+    not(feature = "async"),
+    async(feature = "async", tokio::test(flavor = "current_thread"))
+))]
+#[serial]
+async fn test_lease_cache_hit_reuses_file_id() -> smb::Result<()> {
+    use smb::FileAccessMask;
+    let share = smb_tests_share();
+    let (client, share_path) = make_server_connection(&share, None).await?;
+    let conn = client.get_connection(share_path.server()).await?;
+    let info = conn.conn_info().expect("connection negotiated");
+    if !info.negotiation.caps.leasing() {
+        tracing::warn!("Server lacks caps.leasing(); skipping C.3 cache-hit test.");
+        return Ok(());
+    }
+
+    // Use OverwriteIf for the initial set-up Create so we don't depend on
+    // prior test state; cache-hit Open will use CreateDisposition::Open
+    // which is the only disposition try_acquire_for_reuse accepts.
+    let path_rel = "lease_phase_c3_hit.txt";
+    let unc = share_path.with_path(path_rel);
+
+    // Step 1: prime the cache. OverwriteIf + GenericAll, with lease.
+    let args_prime = FileCreateArgs::make_overwrite(Default::default(), Default::default())
+        .with_lease(make_lease_request());
+    let file_first = client
+        .create_file(&unc, &args_prime)
+        .await?
+        .into_file()
+        .expect("Resource must be a file");
+    let grant_first = file_first
+        .handle()
+        .lease_granted()
+        .expect("server with caps.leasing() must issue a grant");
+    let file_id_first = file_first.handle().raw_file_id();
+    assert!(
+        grant_first.state.handle_caching(),
+        "cache-hit test relies on handle_caching being granted; got {:?}",
+        grant_first.state,
+    );
+
+    // Step 2: close — but with a lease slot attached, this must be a
+    // deferred close. The slot stays in the cache.
+    file_first.close().await?;
+    let slot_after_close = conn
+        .peek_lease_slot(path_rel)
+        .await?
+        .expect("deferred close must leave the slot in the cache");
+    assert!(
+        !slot_after_close.tombstoned.load(std::sync::atomic::Ordering::Acquire),
+        "no break happened, slot must still be alive (not tombstoned)",
+    );
+    assert_eq!(
+        slot_after_close.refcount.load(std::sync::atomic::Ordering::Acquire),
+        0,
+        "refcount returns to 0 after close, but slot stays cached",
+    );
+
+    // Step 3: reopen with CreateDisposition::Open + matching access. The
+    // returned Resource must reuse the cached FileId — no new Create RT
+    // hit the wire. We assert FileId equality as the wire-observable
+    // proof.
+    let args_reopen = FileCreateArgs::make_open_existing(
+        FileAccessMask::new().with_generic_all(true),
+    )
+    .with_lease(make_lease_request());
+    let file_second = client
+        .create_file(&unc, &args_reopen)
+        .await?
+        .into_file()
+        .expect("Resource must be a file");
+    let file_id_second = file_second.handle().raw_file_id();
+    assert_eq!(
+        file_id_second, file_id_first,
+        "cache hit must reuse the original FileId (saving a Create RT)",
+    );
+    assert_eq!(
+        slot_after_close.refcount.load(std::sync::atomic::Ordering::Acquire),
+        1,
+        "second open bumps refcount back to 1",
+    );
+
+    // Step 4: cleanup. set_info+close on the second handle marks the file
+    // for delete. Because the slot was never tombstoned (no server-side
+    // break), this close defers again — the file still gets deleted by
+    // virtue of the dispose flag carrying into the eventual wire close.
+    // We then provoke a tombstone via a flush_idle equivalent: a
+    // separate client opening the file would force a break, but here we
+    // just let drop() of the connection close everything at test end.
+    file_second
+        .set_info(FileDispositionInformation::default())
+        .await?;
+    file_second.close().await?;
+    Ok(())
+}

--- a/crates/smb/tests/lease.rs
+++ b/crates/smb/tests/lease.rs
@@ -17,20 +17,12 @@
 //! SMB 2.1+ server advertising `caps.leasing()` is sufficient.
 
 mod common;
-use common::{TestConstants, make_server_connection};
+use common::{make_server_connection, smb_tests_share};
 use serial_test::serial;
 use smb::{FileCreateArgs, RequestLease, RequestLeaseV2};
 use smb_fscc::FileDispositionInformation;
 use smb_msg::{LeaseFlags, LeaseState};
-use std::env;
-
-/// Reads the share name from `SMB_RUST_TESTS_SHARE`, falling back to the
-/// shared `TestConstants::DEFAULT_SHARE` when unset. Allows smoke-testing
-/// against real lease-supporting servers (e.g. `jay_cifs1`) without
-/// rebuilding the test binary.
-fn test_share() -> String {
-    env::var("SMB_RUST_TESTS_SHARE").unwrap_or_else(|_| TestConstants::DEFAULT_SHARE.to_string())
-}
+use std::time::Duration;
 
 /// Random-but-stable 128-bit lease key for the test. A real client would
 /// generate a fresh UUID per open; a constant value is fine in a serial test
@@ -58,7 +50,7 @@ fn make_lease_request() -> RequestLease {
 ))]
 #[serial]
 async fn test_lease_request_create_new() -> smb::Result<()> {
-    let share = test_share();
+    let share = smb_tests_share();
     let (client, share_path) = make_server_connection(&share, None).await?;
 
     // Inspect the negotiated capabilities so we can interpret the result:
@@ -122,7 +114,7 @@ async fn test_no_lease_request_has_no_grant() -> smb::Result<()> {
     // never produce a grant, regardless of server capability. This proves
     // Phase A's `lease_requested` gate correctly suppresses parsing when
     // the client didn't ask.
-    let share = test_share();
+    let share = smb_tests_share();
     let (client, share_path) = make_server_connection(&share, None).await?;
 
     let args = FileCreateArgs::make_overwrite(Default::default(), Default::default());
@@ -141,5 +133,111 @@ async fn test_no_lease_request_has_no_grant() -> smb::Result<()> {
 
     file.set_info(FileDispositionInformation::default()).await?;
     file.close().await?;
+    Ok(())
+}
+
+/// Phase B (LeaseBreakNotify reception + auto-Ack):
+///
+/// Client A opens a file with a HandleCaching+ReadCaching lease, then a
+/// separate Client B opens the same path. The server is required to break
+/// the handle-caching component of A's lease and send a `LeaseBreakNotify`;
+/// the smb-rs connection task receives it, auto-sends a `LeaseBreakAck`,
+/// and fans out a `LeaseBreakEvent` to subscribers — which is what this
+/// test waits for.
+///
+/// This is the end-to-end proof that Phase B's wire-level integration
+/// works: subscription + decode + ack + fan-out. Unit-testable in isolation
+/// is the decode/fan-out; only a real server can drive the break.
+#[test_log::test(maybe_async::test(
+    not(feature = "async"),
+    async(feature = "async", tokio::test(flavor = "current_thread"))
+))]
+#[serial]
+async fn test_lease_break_notify_fanned_out() -> smb::Result<()> {
+    let share = smb_tests_share();
+
+    // Client A: holds the lease, subscribes to breaks.
+    let (client_a, share_path_a) = make_server_connection(&share, None).await?;
+    let conn = client_a.get_connection(share_path_a.server()).await?;
+    let info = conn.conn_info().expect("connection negotiated");
+    if !info.negotiation.caps.leasing() {
+        tracing::warn!(
+            "Server does not advertise caps.leasing(); Phase B break test \
+             cannot run against this server. Skipping."
+        );
+        return Ok(());
+    }
+
+    let mut break_rx = client_a
+        .subscribe_lease_breaks(share_path_a.server())
+        .await?;
+
+    let path = share_path_a.with_path("lease_phase_b_break.txt");
+    let lease = RequestLease::RqLsReqv2(RequestLeaseV2 {
+        lease_key: TEST_LEASE_KEY,
+        lease_state: LeaseState::new()
+            .with_read_caching(true)
+            .with_handle_caching(true),
+        lease_flags: LeaseFlags::new(),
+        parent_lease_key: 0,
+        epoch: 0,
+    });
+    let args_a = FileCreateArgs::make_overwrite(Default::default(), Default::default())
+        .with_lease(lease);
+    let file_a = client_a
+        .create_file(&path, &args_a)
+        .await?
+        .into_file()
+        .expect("Resource must be a file");
+
+    let grant = file_a
+        .handle()
+        .lease_granted()
+        .expect("server with caps.leasing() must issue a grant");
+    tracing::info!("Client A holds lease: {grant:?}");
+    assert!(
+        grant.state.handle_caching(),
+        "test relies on handle_caching to provoke a break on B's open",
+    );
+
+    // Client B: independent connection to same server, opens the same path
+    // with OverwriteIf + GenericAll — strongly conflicts with A's
+    // HandleCaching+ReadCaching lease. Per MS-SMB2 2.2.23.2 the server must
+    // send a LeaseBreakNotify to A before completing B's Create.
+    let (client_b, share_path_b) = make_server_connection(&share, None).await?;
+    let path_b = share_path_b.with_path("lease_phase_b_break.txt");
+    let file_b = client_b
+        .create_file(
+            &path_b,
+            &FileCreateArgs::make_overwrite(Default::default(), Default::default()),
+        )
+        .await?
+        .into_file()
+        .expect("Resource must be a file");
+
+    // Bounded wait so a misbehaving server can't hang CI.
+    let event = tokio::time::timeout(Duration::from_secs(10), break_rx.recv())
+        .await
+        .expect("LeaseBreakNotify must arrive within 10s of B's conflicting open")
+        .expect("broadcast channel must remain open while client A is alive");
+
+    tracing::info!("Client A received break event: {event:?}");
+    assert_eq!(
+        event.lease_key.as_u128(),
+        grant.key,
+        "break must target the lease we acquired (compared via u128 since \
+         LeaseBreakNotify uses Guid while RequestLease uses u128)",
+    );
+    assert!(
+        !event.new_state.handle_caching(),
+        "server must drop handle_caching when another client opens the file",
+    );
+
+    // Cleanup: drop B first so A's set_info can mark the file for delete.
+    drop(file_b);
+    file_a
+        .set_info(FileDispositionInformation::default())
+        .await?;
+    file_a.close().await?;
     Ok(())
 }

--- a/crates/smb/tests/lease.rs
+++ b/crates/smb/tests/lease.rs
@@ -494,3 +494,178 @@ async fn test_lease_cache_hit_reuses_file_id() -> smb::Result<()> {
     file_second.close().await?;
     Ok(())
 }
+
+/// Phase C.5 (explicit eviction):
+///
+/// `Client::evict_lease(path)` removes the cached slot and sends the
+/// wire `Close` immediately when no live handle is referencing the
+/// slot. After eviction, a subsequent open with the same lease request
+/// must miss the cache and get a *fresh* FileId, proving the prior
+/// FileId was actually released on the server side.
+///
+/// We also verify the idempotent / safe-on-empty behavior — calling
+/// `evict_lease` twice in a row returns `false` the second time.
+#[test_log::test(maybe_async::test(
+    not(feature = "async"),
+    async(feature = "async", tokio::test(flavor = "current_thread"))
+))]
+#[serial]
+async fn test_evict_lease_releases_slot_and_misses_next_open() -> smb::Result<()> {
+    let share = smb_tests_share();
+    let (client, share_path) = make_server_connection(&share, None).await?;
+    let conn = client.get_connection(share_path.server()).await?;
+    let info = conn.conn_info().expect("connection negotiated");
+    if !info.negotiation.caps.leasing() {
+        tracing::warn!("Server lacks caps.leasing(); skipping C.5 evict test.");
+        return Ok(());
+    }
+
+    let path_rel = "lease_phase_c5_evict.txt";
+    let unc = share_path.with_path(path_rel);
+
+    // Prime the cache: open with HandleCaching, then close — slot stays.
+    let args_prime = FileCreateArgs::make_overwrite(Default::default(), Default::default())
+        .with_lease(make_lease_request());
+    let file_first = client
+        .create_file(&unc, &args_prime)
+        .await?
+        .into_file()
+        .expect("Resource must be a file");
+    let file_id_first = file_first.handle().raw_file_id();
+    let grant_first = file_first
+        .handle()
+        .lease_granted()
+        .expect("server with caps.leasing() must issue a grant");
+    assert!(
+        grant_first.state.handle_caching(),
+        "evict test relies on handle_caching being granted; got {:?}",
+        grant_first.state,
+    );
+    file_first.close().await?;
+    assert!(
+        conn.peek_lease_slot(path_rel).await?.is_some(),
+        "slot must survive deferred close",
+    );
+
+    // Explicit eviction returns true the first time, false the second
+    // (idempotent), and removes the entry from the table.
+    assert!(
+        client.evict_lease(&unc).await?,
+        "first evict must find and remove the slot",
+    );
+    assert!(
+        !client.evict_lease(&unc).await?,
+        "second evict on the same path is a no-op",
+    );
+    assert!(
+        conn.peek_lease_slot(path_rel).await?.is_none(),
+        "evicted slot must be gone from the table",
+    );
+
+    // After eviction the server has released the FileId; a fresh open
+    // with the same args must get a *new* FileId, not the cached one.
+    let args_reopen = FileCreateArgs::make_overwrite(Default::default(), Default::default())
+        .with_lease(make_lease_request());
+    let file_second = client
+        .create_file(&unc, &args_reopen)
+        .await?
+        .into_file()
+        .expect("Resource must be a file");
+    let file_id_second = file_second.handle().raw_file_id();
+    assert_ne!(
+        file_id_second, file_id_first,
+        "after eviction the server must allocate a fresh FileId",
+    );
+
+    file_second
+        .set_info(FileDispositionInformation::default())
+        .await?;
+    file_second.close().await?;
+    // Final cleanup: evict so the deferred-close file_id is sent
+    // properly. With dispose set, this completes the delete.
+    let _ = client.evict_lease(&unc).await;
+    Ok(())
+}
+
+/// Phase C.5 (idle sweep):
+///
+/// `Client::flush_idle_leases(server, older_than)` should walk the
+/// per-connection lease table and tombstone+evict slots whose
+/// `last_used` is older than the threshold. The wire `Close` for
+/// refcount-0 slots is sent during the sweep.
+///
+/// We open a file with a lease, close it (slot retained), wait briefly,
+/// then call flush_idle_leases with a very small threshold. The slot
+/// must be gone afterwards and a re-open returns a fresh FileId.
+#[test_log::test(maybe_async::test(
+    not(feature = "async"),
+    async(feature = "async", tokio::test(flavor = "current_thread"))
+))]
+#[serial]
+async fn test_flush_idle_leases_sweeps_old_slots() -> smb::Result<()> {
+    let share = smb_tests_share();
+    let (client, share_path) = make_server_connection(&share, None).await?;
+    let conn = client.get_connection(share_path.server()).await?;
+    let info = conn.conn_info().expect("connection negotiated");
+    if !info.negotiation.caps.leasing() {
+        tracing::warn!("Server lacks caps.leasing(); skipping C.5 idle-sweep test.");
+        return Ok(());
+    }
+
+    let path_rel = "lease_phase_c5_idle.txt";
+    let server = share_path.server().to_string();
+    let unc = share_path.with_path(path_rel);
+
+    let args_prime = FileCreateArgs::make_overwrite(Default::default(), Default::default())
+        .with_lease(make_lease_request());
+    let file = client
+        .create_file(&unc, &args_prime)
+        .await?
+        .into_file()
+        .expect("Resource must be a file");
+    let file_id_first = file.handle().raw_file_id();
+    file.close().await?;
+
+    // Confirm the slot is there.
+    assert!(
+        conn.peek_lease_slot(path_rel).await?.is_some(),
+        "deferred close must keep the slot cached",
+    );
+
+    // Wait past the threshold then sweep. We use 100ms to keep the test
+    // fast; in production this would be minutes.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    let swept = client
+        .flush_idle_leases(&server, Duration::from_millis(50))
+        .await?;
+    assert!(
+        swept >= 1,
+        "sweep must claim at least our own idle slot, got {swept}",
+    );
+    assert!(
+        conn.peek_lease_slot(path_rel).await?.is_none(),
+        "swept slot must be gone from the table",
+    );
+
+    // Confirm the FileId is now stale on the server side: a fresh open
+    // gets a different FileId.
+    let args_reopen = FileCreateArgs::make_overwrite(Default::default(), Default::default())
+        .with_lease(make_lease_request());
+    let file_again = client
+        .create_file(&unc, &args_reopen)
+        .await?
+        .into_file()
+        .expect("Resource must be a file");
+    assert_ne!(
+        file_again.handle().raw_file_id(),
+        file_id_first,
+        "after idle-sweep, the server has released the original FileId",
+    );
+
+    file_again
+        .set_info(FileDispositionInformation::default())
+        .await?;
+    file_again.close().await?;
+    let _ = client.evict_lease(&unc).await;
+    Ok(())
+}

--- a/crates/smb/tests/lease.rs
+++ b/crates/smb/tests/lease.rs
@@ -1,0 +1,145 @@
+//! Integration tests for `FileCreateArgs::lease_request` (Phase A of Handle Lease).
+//!
+//! These tests verify the end-to-end wire behavior against a real SMB server:
+//!  1. Client sends an `RqLs` create context with the Create request.
+//!  2. Server responds with an `RqLs` response context when it supports leasing.
+//!  3. `ResourceHandle::lease_granted()` exposes the parsed grant to callers.
+//!
+//! Phase A is **infrastructure only** — opening with a lease still costs a full
+//! `Create + Close` round-trip. Phases B-D introduce break handling and deferred
+//! close that actually skip RTs.
+//!
+//! ## Running
+//!
+//! These tests connect to whatever server `SMB_RUST_TESTS_SERVER` points at
+//! (defaults to `127.0.0.1`, expecting the docker-compose Samba setup from
+//! `crates/smb/tests/README.md`). They are not gated to any particular IP; any
+//! SMB 2.1+ server advertising `caps.leasing()` is sufficient.
+
+mod common;
+use common::{TestConstants, make_server_connection};
+use serial_test::serial;
+use smb::{FileCreateArgs, RequestLease, RequestLeaseV2};
+use smb_fscc::FileDispositionInformation;
+use smb_msg::{LeaseFlags, LeaseState};
+use std::env;
+
+/// Reads the share name from `SMB_RUST_TESTS_SHARE`, falling back to the
+/// shared `TestConstants::DEFAULT_SHARE` when unset. Allows smoke-testing
+/// against real lease-supporting servers (e.g. `jay_cifs1`) without
+/// rebuilding the test binary.
+fn test_share() -> String {
+    env::var("SMB_RUST_TESTS_SHARE").unwrap_or_else(|_| TestConstants::DEFAULT_SHARE.to_string())
+}
+
+/// Random-but-stable 128-bit lease key for the test. A real client would
+/// generate a fresh UUID per open; a constant value is fine in a serial test
+/// because the prior test's lease is released when the file is closed.
+const TEST_LEASE_KEY: u128 = 0x4C45_4153_4520_5445_5354_204B_4559_2121_u128;
+
+/// Build a v2 lease request asking for Read + Handle caching. Servers that
+/// don't support leasing will silently omit the response context; we'll
+/// observe that as `lease_granted() == None`.
+fn make_lease_request() -> RequestLease {
+    RequestLease::RqLsReqv2(RequestLeaseV2 {
+        lease_key: TEST_LEASE_KEY,
+        lease_state: LeaseState::new()
+            .with_read_caching(true)
+            .with_handle_caching(true),
+        lease_flags: LeaseFlags::new(),
+        parent_lease_key: 0,
+        epoch: 0,
+    })
+}
+
+#[test_log::test(maybe_async::test(
+    not(feature = "async"),
+    async(feature = "async", tokio::test(flavor = "current_thread"))
+))]
+#[serial]
+async fn test_lease_request_create_new() -> smb::Result<()> {
+    let share = test_share();
+    let (client, share_path) = make_server_connection(&share, None).await?;
+
+    // Inspect the negotiated capabilities so we can interpret the result:
+    // a server without `caps.leasing()` is expected to return None, and we
+    // skip the positive assertion instead of treating it as a failure.
+    let conn = client.get_connection(share_path.server()).await?;
+    let info = conn.conn_info().expect("share_connect completed → negotiated");
+    let server_supports_leasing = info.negotiation.caps.leasing();
+    tracing::info!(
+        "Negotiated: dialect={:?}, leasing={}, multi_channel={}",
+        info.negotiation.dialect_rev,
+        server_supports_leasing,
+        info.negotiation.caps.multi_channel()
+    );
+
+    // OverwriteIf instead of Create — makes the test idempotent across reruns
+    // (a prior failed run may have left the file behind without deleting it).
+    let args = FileCreateArgs::make_overwrite(Default::default(), Default::default())
+        .with_lease(make_lease_request());
+
+    let file = client
+        .create_file(&share_path.with_path("lease_phase_a.txt"), &args)
+        .await?
+        .into_file()
+        .expect("created resource must be a file");
+
+    let grant = file.handle().lease_granted();
+    tracing::info!("server lease_granted={:?}", grant);
+
+    if server_supports_leasing {
+        let g = grant.expect("server supports leasing → grant must be Some");
+        assert_eq!(g.key, TEST_LEASE_KEY, "server must echo our lease key");
+        // Server may downgrade requested state (e.g., drop handle_caching).
+        // Phase A only verifies the grant was parsed; the actual state is
+        // whatever the server chose to issue.
+        assert!(
+            g.state.read_caching() || g.state.handle_caching() || g.state.write_caching(),
+            "at least one caching bit must be set when grant is Some"
+        );
+    } else {
+        // Servers without leasing capability must not produce a grant.
+        assert!(
+            grant.is_none(),
+            "server lacks leasing capability but produced a grant: {:?}",
+            grant
+        );
+    }
+
+    file.set_info(FileDispositionInformation::default()).await?;
+    file.close().await?;
+    Ok(())
+}
+
+#[test_log::test(maybe_async::test(
+    not(feature = "async"),
+    async(feature = "async", tokio::test(flavor = "current_thread"))
+))]
+#[serial]
+async fn test_no_lease_request_has_no_grant() -> smb::Result<()> {
+    // Control case: default FileCreateArgs (no lease_request) → server must
+    // never produce a grant, regardless of server capability. This proves
+    // Phase A's `lease_requested` gate correctly suppresses parsing when
+    // the client didn't ask.
+    let share = test_share();
+    let (client, share_path) = make_server_connection(&share, None).await?;
+
+    let args = FileCreateArgs::make_overwrite(Default::default(), Default::default());
+    assert!(args.lease_request.is_none(), "control: args must have no lease");
+
+    let file = client
+        .create_file(&share_path.with_path("lease_phase_a_no_lease.txt"), &args)
+        .await?
+        .into_file()
+        .expect("created resource must be a file");
+
+    assert!(
+        file.handle().lease_granted().is_none(),
+        "no lease_request → grant must be None"
+    );
+
+    file.set_info(FileDispositionInformation::default()).await?;
+    file.close().await?;
+    Ok(())
+}

--- a/crates/smb/tests/lease.rs
+++ b/crates/smb/tests/lease.rs
@@ -669,3 +669,99 @@ async fn test_flush_idle_leases_sweeps_old_slots() -> smb::Result<()> {
     let _ = client.evict_lease(&unc).await;
     Ok(())
 }
+
+/// Phase D (default lease injection):
+///
+/// `ClientConfig::default_lease_state = Some(...)` makes every
+/// `create_file` call request a lease without the caller having to
+/// build a RequestLease per call. Two opens of the same path on the
+/// same Client should:
+///   1. Get a lease granted on the first call (proving auto-injection
+///      worked end-to-end).
+///   2. Hit the cache on the second call — same FileId — proving the
+///      auto-injected lease keys are stable per path within a Client.
+#[test_log::test(maybe_async::test(
+    not(feature = "async"),
+    async(feature = "async", tokio::test(flavor = "current_thread"))
+))]
+#[serial]
+async fn test_client_default_lease_state_auto_injects() -> smb::Result<()> {
+    use smb::{Client, ClientConfig, FileAccessMask};
+    let share = smb_tests_share();
+    let mut config = ClientConfig::default();
+    let mut conn_config = smb::ConnectionConfig::default();
+    conn_config.timeout = Some(Duration::from_secs(10));
+    conn_config.auth_methods.kerberos = false;
+    conn_config.auth_methods.ntlm = true;
+    config.connection = conn_config;
+    config.default_lease_state = Some(
+        LeaseState::new()
+            .with_read_caching(true)
+            .with_handle_caching(true),
+    );
+
+    let server = std::env::var("SMB_RUST_TESTS_SERVER").unwrap_or_else(|_| "127.0.0.1".to_string());
+    let user = std::env::var("SMB_RUST_TESTS_USER_NAME").unwrap_or_else(|_| "LocalAdmin".to_string());
+    let password =
+        std::env::var("SMB_RUST_TESTS_PASSWORD").unwrap_or_else(|_| "123456".to_string());
+    let client = Client::new(config);
+    let unc_share = smb::UncPath::new(&server)?.with_share(&share)?;
+    client
+        .share_connect(&unc_share, user.as_str(), password)
+        .await?;
+
+    let conn = client.get_connection(&server).await?;
+    let info = conn.conn_info().expect("connection negotiated");
+    if !info.negotiation.caps.leasing() {
+        tracing::warn!("Server lacks caps.leasing(); skipping Phase D auto-inject test.");
+        return Ok(());
+    }
+
+    let path_rel = "lease_phase_d_auto.txt";
+    let unc = unc_share.with_path(path_rel);
+
+    // No `.with_lease(...)` on args — relying purely on config.
+    let args_no_lease = FileCreateArgs::make_overwrite(Default::default(), Default::default());
+    assert!(
+        args_no_lease.lease_request.is_none(),
+        "control: args must not carry a lease at the call site",
+    );
+
+    let file_first = client
+        .create_file(&unc, &args_no_lease)
+        .await?
+        .into_file()
+        .expect("Resource must be a file");
+    let grant = file_first
+        .handle()
+        .lease_granted()
+        .expect("config.default_lease_state must trigger a grant");
+    assert!(
+        grant.state.handle_caching(),
+        "auto-injected lease must request handle_caching",
+    );
+    let file_id_first = file_first.handle().raw_file_id();
+    file_first.close().await?;
+
+    // Second open also without explicit lease — must hit the cache.
+    let args_reopen = FileCreateArgs::make_open_existing(
+        FileAccessMask::new().with_generic_all(true),
+    );
+    let file_second = client
+        .create_file(&unc, &args_reopen)
+        .await?
+        .into_file()
+        .expect("Resource must be a file");
+    assert_eq!(
+        file_second.handle().raw_file_id(),
+        file_id_first,
+        "auto-injected lease must yield stable lease key → cache hits",
+    );
+
+    file_second
+        .set_info(FileDispositionInformation::default())
+        .await?;
+    file_second.close().await?;
+    let _ = client.evict_lease(&unc).await;
+    Ok(())
+}

--- a/crates/smb/tests/lease.rs
+++ b/crates/smb/tests/lease.rs
@@ -670,6 +670,101 @@ async fn test_flush_idle_leases_sweeps_old_slots() -> smb::Result<()> {
     Ok(())
 }
 
+/// P2.b: compound Create+SetInfo+Close in a single SMB2 request.
+///
+/// The client builds a 3-member chain (Create with `Open` disposition,
+/// SetInfo of FileBasicInformation, Close) and sends it as one wire
+/// write. The server returns 3 chained responses; the worker dispatches
+/// each by message_id, the helper checks each status, and the new mtime
+/// must be visible on a fresh stat afterward.
+///
+/// We verify three things:
+/// 1. The helper succeeds (all 3 wire responses status=SUCCESS).
+/// 2. The destination file's mtime was actually written (we pick a
+///    distinctive value far enough from "now" that the server's
+///    auto-update on Create can't accidentally match).
+/// 3. creation_time was NOT clobbered (we sent 0 for it, which means
+///    "preserve" per MS-FSCC 2.4.7).
+#[test_log::test(maybe_async::test(
+    not(feature = "async"),
+    async(feature = "async", tokio::test(flavor = "current_thread"))
+))]
+#[serial]
+async fn test_compound_set_basic_info() -> smb::Result<()> {
+    use smb::{FileAccessMask, FileBasicInformation};
+    use smb::binrw_util::file_time::FileTime;
+
+    let share = smb_tests_share();
+    let (client, share_path) = make_server_connection(&share, None).await?;
+
+    let path_rel = "compound_p2b.txt";
+    let unc = share_path.with_path(path_rel);
+
+    // Seed the file so Open will succeed and we have a known starting
+    // state. Capture the original creation_time to assert preservation.
+    let prime_args = FileCreateArgs::make_overwrite(Default::default(), Default::default());
+    let f = client
+        .create_file(&unc, &prime_args)
+        .await?
+        .into_file()
+        .expect("must be file");
+    let creation_before: FileTime = f.handle().created().into();
+    f.close().await?;
+
+    // Pick a distinctive target mtime: 2020-06-15 12:00:00 UTC.
+    // (Unix epoch 1592_222_400 sec → expressed in 100ns Windows FileTime
+    // = (1592222400 + 11644473600) * 10_000_000 = 132373770400000000.)
+    let target_mtime = FileTime::from(132_373_770_400_000_000u64);
+
+    // Build the basic with creation/change/atime/attrs = 0 (preserve)
+    // and last_write_time set to our target. P2.b's compound helper
+    // sends this as one wire RT.
+    let basic = FileBasicInformation {
+        creation_time: FileTime::default(),
+        last_access_time: FileTime::default(),
+        last_write_time: target_mtime,
+        change_time: FileTime::default(),
+        file_attributes: smb_fscc::FileAttributes::new(),
+    };
+    client.compound_set_basic_info(&unc, basic).await?;
+
+    // Verify: open the file, query its FileBasicInformation, and
+    // check both the new mtime stuck AND creation_time was preserved.
+    let verify_args =
+        FileCreateArgs::make_open_existing(FileAccessMask::new().with_file_read_attributes(true));
+    let v = client
+        .create_file(&unc, &verify_args)
+        .await?
+        .into_file()
+        .expect("must be file");
+    let queried: FileBasicInformation = v
+        .handle()
+        .query_info()
+        .await
+        .expect("query basic info");
+    assert_eq!(
+        *queried.last_write_time, *target_mtime,
+        "compound SetInfo's last_write_time must be visible after the chain's Close commits",
+    );
+    assert_eq!(
+        *queried.creation_time, *creation_before,
+        "creation_time = 0 in SetInfo must leave the server's stored creation_time unchanged (MS-FSCC 2.4.7)",
+    );
+    v.close().await?;
+
+    // Cleanup
+    let cleanup_args =
+        FileCreateArgs::make_open_existing(FileAccessMask::new().with_delete(true));
+    let c = client
+        .create_file(&unc, &cleanup_args)
+        .await?
+        .into_file()
+        .expect("must be file");
+    c.set_info(FileDispositionInformation::default()).await?;
+    c.close().await?;
+    Ok(())
+}
+
 /// Phase D (default lease injection):
 ///
 /// `ClientConfig::default_lease_state = Some(...)` makes every


### PR DESCRIPTION
## Summary

Implements full SMB 2.x **Handle Lease** support (MS-SMB2 2.2.13.2.10) and **SMB2 compound requests** (MS-SMB2 3.2.4.1.4) on top of the existing single-message infrastructure.

Driven by the [terrasync-rs](https://github.com/JayTsu-sh/terrasync-rs) CIFS sync workload — wire-RT analysis under `docs/perf/cifs-sync-optimization.md` in terrasync-rs motivated each phase.

## Phases

| Phase | Commit | LOC | What it adds |
|---|---|---|---|
| A | `ce4f736` | ~150 | `FileCreateArgs::lease_request` + `LeaseGrant` parsing from `RqLs` CreateContext |
| B | `b6aa563` | ~200 | `LeaseBreakNotify` reception + auto-`LeaseBreakAck` + `Client::subscribe_lease_breaks` |
| C.1+C.2 | `ad3fcef` | ~250 | Per-connection `lease_table: HashMap<path, Arc<LeaseSlot>>` + break-driven tombstoning |
| C.3+C.4 | `4302aef` | ~250 | Cache-hit on reopen (reuses `FileId`, 0 RT) + deferred Close via slot refcount |
| C.5 | `f4ca742` | ~150 | `Client::evict_lease(unc)` + `Client::flush_idle_leases(server, older_than)` |
| D | `d4a51bd` | ~80 | `ClientConfig::default_lease_state` + per-Client `lease_key_salt` for path-derived keys |
| Compound | \`446cac6\`/\`59d9a3e\`/\`efd37dd\` | ~500 | \`Transformer::transform_{incoming_all,outgoing_compound}\` + \`Worker::send_compound\` + \`Client::compound_set_basic_info\` |
| Code-review | `04e426d` | — | sign-after-pad, displaced-slot tombstone, sweep overflow guard, break race close |

## New public APIs

\`\`\`rust
// Phase A
impl FileCreateArgs { pub fn with_lease(self, RequestLease) -> Self; }
impl ResourceHandle { pub fn lease_granted(&self) -> Option<LeaseGrant>; }
pub struct LeaseGrant { pub key: u128, pub state: LeaseState, pub epoch: u16 }

// Phase B
pub struct LeaseBreakEvent { ... }
impl Client { pub async fn subscribe_lease_breaks(&self, server: &str) -> Result<broadcast::Receiver<LeaseBreakEvent>>; }

// Phase C / D / P2.b
impl Client {
    pub async fn evict_lease(&self, unc: &UncPath) -> Result<bool>;
    pub async fn flush_idle_leases(&self, server: &str, older_than: Duration) -> Result<usize>;
    pub async fn compound_set_basic_info(&self, path: &UncPath, basic: FileBasicInformation) -> Result<()>;
}
pub struct ClientConfig {
    /* existing fields ... */
    default_lease_state: Option<LeaseState>,
    lease_key_salt: u64,
}
\`\`\`

## Performance impact

Single-file \`update_metadata\` path RT count (typical sync flow):
- **Baseline**: 6 wire RTs (\`open + open(read) + query + set + close*2\`)
- **Phase D + P2.a** (skip query_info via MS-FSCC 0=preserve): 4 RTs
- **P2.b** compound: **2 RTs** (\`evict + compound(create+setinfo+close)\`)

For typical LAN (~2ms/RT), 1k-file metadata sync saves ~8 s.

## Test plan

- [x] 16 smb unit tests pass
- [x] 10 lease integration tests pass against a leasing-capable server (NetApp + Samba @ 10.131.7.203) — covers grant parsing, break notify+ack, cache-hit/miss, deferred close, explicit eviction, idle sweep, auto-inject, compound set basic info
- [x] End-to-end CIFS→CIFS sync + integrity-check \`All Passed ✓\` (4 files / 3 dirs)
- [x] Workspace builds clean across feature flags
- [x] Servers without \`caps.leasing()\` silently no-op (server drops the RqLs context, client code falls back to the legacy path)

## Notes / Limitations

- Compound encoder **does not yet support** per-member encryption or zero-copy \`additional_data\` bodies (returns \`InvalidArgument\`). The only current caller (\`compound_set_basic_info\`) needs neither.
- Lease cache is **per-connection** (one \`lease_table\` per \`Connection\`). Cross-Client sharing is intentionally out of scope — making it a connection-level singleton would funnel all SMB I/O through one async_backend queue and serialize multi-worker writes.
- Lease key derivation uses \`std::collections::hash_map::DefaultHasher\` which is not stable across Rust versions; mitigated by a random per-Client \`lease_key_salt\`. Safe for single-process deployment.
- The code-review pass commit (\`04e426d\`) fixes a CRITICAL sign-before-pad bug in compound: per MS-SMB2 3.1.4.1 the per-member signature must cover the 8-byte alignment padding between members. Test server happened to be lenient pre-fix; spec-correctness restored.

## File-by-file diff

\`\`\`
 crates/smb-msg/src/create.rs                      |   3 +
 crates/smb-msg/src/oplock.rs                      |  20 +-
 crates/smb/src/client/config.rs                   |  31 +
 crates/smb/src/client/smb_client.rs               | 397 +++++++++-
 crates/smb/src/connection.rs                      | 695 +++++++++++++++-
 crates/smb/src/connection/transformer.rs          | 289 ++++++++
 crates/smb/src/connection/worker/parallel/base.rs |  98 ++-
 crates/smb/src/lease.rs                           | 288 ++++++++
 crates/smb/src/lib.rs                             |   2 +-
 crates/smb/src/msg_handler.rs                     |   2 +-
 crates/smb/src/resource.rs                        | 430 ++++++++++-
 crates/smb/src/resource/file.rs                   |  13 +-
 crates/smb/src/resource/pipe.rs                   |   4 +-
 crates/smb/src/session/channel.rs                 |  14 +
 crates/smb/src/tree.rs                            |  18 +
 crates/smb/tests/common.rs                        |  10 +
 crates/smb/tests/lease.rs                         | 862 ++++++++++++++++++++++
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)