### PR TITLE
fix(smb): post-merge review pass — workspace compat + compound/lease hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2419,6 +2419,7 @@ dependencies = [
  "reqwest",
  "serial_test",
  "sha2",
+ "siphasher",
  "smb-dtyp",
  "smb-fscc",
  "smb-msg",

--- a/crates/smb-transport/src/tcp/transport.rs
+++ b/crates/smb-transport/src/tcp/transport.rs
@@ -247,7 +247,6 @@ impl SmbTransportWrite for TcpTransport {
         }
         .boxed()
     }
-
 }
 
 impl SmbTransportRead for TcpTransport {

--- a/crates/smb/Cargo.toml
+++ b/crates/smb/Cargo.toml
@@ -40,6 +40,11 @@ tracing = { workspace = true }
 time = { workspace = true }
 thiserror = { workspace = true }
 pastey = { workspace = true }
+# Stable keyed hash used to derive per-path lease keys from the client's
+# random salt. std::DefaultHasher's algorithm is explicitly unstable
+# across Rust versions, which would break lease-cache reuse across
+# rustc upgrades for callers that pin lease_key_salt.
+siphasher = "1"
 
 url = "2.5.0"
 byteorder = { version = "1.5.0", optional = true }

--- a/crates/smb/src/client/smb_client.rs
+++ b/crates/smb/src/client/smb_client.rs
@@ -452,7 +452,10 @@ impl Client {
                 let slot = std::sync::Arc::new(crate::lease::LeaseSlot::new_with_proto(
                     rel.clone(),
                     tree.tree_id(),
-                    resource.handle().map(|h| h.raw_file_id()).unwrap_or_default(),
+                    resource
+                        .handle()
+                        .map(|h| h.raw_file_id())
+                        .unwrap_or_default(),
                     grant.key,
                     grant.state,
                     proto,
@@ -479,29 +482,37 @@ impl Client {
     }
 
     /// Derive a stable 128-bit lease key from the client's
-    /// `lease_key_salt` and the full UNC path. SipHash-flavored mix
-    /// avoids the bad cache behavior of a plain XOR (paths often share
-    /// long common prefixes) and gives enough entropy for the lease
-    /// cache to dedupe paths within a Client without collisions.
+    /// `lease_key_salt` and the full UNC path.
+    ///
+    /// **Stability contract:** the algorithm (SipHash-2-4, keyed) is
+    /// version-stable through the `siphasher` crate, so the same
+    /// `(salt, path)` pair yields the same key across Rust toolchain
+    /// upgrades. This is load-bearing for callers that persist
+    /// `lease_key_salt` and expect a previously-granted lease to remain
+    /// recoverable by key after a rebuild — the previous implementation
+    /// used `std::collections::hash_map::DefaultHasher`, whose
+    /// underlying algorithm is *not* covered by Rust's stability
+    /// guarantees and has already changed once.
+    ///
+    /// Salt is split into two independent 64-bit keys via golden-ratio
+    /// multiplication so the two halves of the 128-bit output don't
+    /// trivially correlate when `salt` has structure (e.g. low entropy
+    /// in test pins). Both halves come from one keyed pass of SipHash
+    /// (`sip128::SipHasher24`), which is enough for collision
+    /// resistance at this scale — a single Client rarely caches more
+    /// than a few thousand paths, well below the birthday bound on
+    /// 128 bits.
     fn derive_lease_key(salt: u64, path: &UncPath) -> u128 {
-        use std::hash::{Hash, Hasher};
-        // Two independent hashers seeded with derived salts give us the
-        // two halves of the 128-bit key. Using `DefaultHasher` (SipHash
-        // under the hood) is good enough for collision resistance at
-        // this scale (a single Client rarely caches more than a few
-        // thousand paths).
-        let path_str = path.to_string();
-        let mut h_lo = std::collections::hash_map::DefaultHasher::new();
-        h_lo.write_u64(salt);
-        path_str.hash(&mut h_lo);
-        let lo = h_lo.finish() as u128;
-
-        let mut h_hi = std::collections::hash_map::DefaultHasher::new();
-        h_hi.write_u64(salt.wrapping_mul(0x9E3779B97F4A7C15));
-        path_str.hash(&mut h_hi);
-        let hi = h_hi.finish() as u128;
-
-        (hi << 64) | lo
+        use siphasher::sip128::{Hasher128, SipHasher24};
+        use std::hash::Hasher;
+        let k0 = salt;
+        let k1 = salt.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+        let mut h = SipHasher24::new_with_keys(k0, k1);
+        // Hash the path as raw bytes rather than via `str::hash`, which
+        // prefixes a length tag whose encoding is also not promised to
+        // be stable. Raw bytes are the most stable thing we can feed.
+        h.write(path.to_string().as_bytes());
+        h.finish128().as_u128()
     }
 
     /// Makes a connection to the specified server.
@@ -753,6 +764,21 @@ impl Client {
         let tree_id = tree.tree_id();
         let session = self.get_session(path).await?;
         let session_id = session.session_id();
+        // Refuse to send a compound chain on a session that requires
+        // encryption — the current minimal compound transformer rejects
+        // per-member `encrypt = true` (see Transformer::transform_outgoing_compound),
+        // so silently falling through here would either leak the chain in
+        // plaintext (on a permissive server) or fail at the transformer
+        // with a less obvious error. Bail loudly with the same intent as
+        // ChannelMessageHandler::sendo, which prefers encryption over
+        // signing on such sessions.
+        if session.should_encrypt().await? {
+            return Err(Error::UnsupportedOperation(
+                "compound_set_basic_info: session requires encryption, but the compound \
+                 path does not yet support per-member encryption"
+                    .to_string(),
+            ));
+        }
         let signed = !session.allow_unsigned().await?;
         let conn = self.get_connection(path.server()).await?;
         let rel = path.path().unwrap_or("");
@@ -776,16 +802,23 @@ impl Client {
         // Member 1: Create with Open disposition. No lease context — we
         // want an immediate Close, not deferred. No DFS — update_metadata
         // is always against already-resolved paths under a connected share.
+        //
+        // `share_access` is fixed at the minimum a SetInfo+Close round
+        // needs: allow concurrent read/write so other handles aren't
+        // locked out for the duration of the chain. We deliberately
+        // do *not* request `delete` share access — this Create is for a
+        // metadata edit, not a delete bracket, and asking for delete
+        // would unnecessarily widen the share permissions a peer holder
+        // must grant us. Callers needing deeper share-mode control
+        // should reach for `update_metadata` directly instead of this
+        // fixed-policy compound helper.
         let create_msg = make_member(
             CreateRequest {
                 requested_oplock_level: OplockLevel::None,
                 impersonation_level: ImpersonationLevel::Impersonation,
                 desired_access: smb_fscc::FileAccessMask::new().with_file_write_attributes(true),
                 file_attributes: smb_fscc::FileAttributes::new(),
-                share_access: ShareAccessFlags::new()
-                    .with_read(true)
-                    .with_write(true)
-                    .with_delete(true),
+                share_access: ShareAccessFlags::new().with_read(true).with_write(true),
                 create_disposition: smb_msg::CreateDisposition::Open,
                 create_options: smb_msg::CreateOptions::new(),
                 name: rel.into(),
@@ -846,11 +879,24 @@ impl Client {
         }
         let close_status = responses[2].message.header.status()?;
         if !matches!(close_status, Status::Success) {
+            // The SetInfo has already committed server-side (it's response
+            // #2 and status was Success). The Close failure means the
+            // server-side FileId stays open until the session disconnects,
+            // which over batch workloads (terrasync-rs syncing tens of
+            // thousands of files) accumulates against the per-session
+            // open-handle limit. Surface this as an error so callers can
+            // decide whether to ignore (best-effort metadata sweep) or
+            // bounce the session. Retrying the whole call is safe — the
+            // SetInfo is idempotent given the same `basic`.
             tracing::warn!(
                 path = %path,
                 status = ?close_status,
-                "compound_set_basic_info: Close failed (server-side handle may leak until session end)",
+                "compound_set_basic_info: SetInfo committed but Close failed; \
+                 server-side FileId will leak until session end",
             );
+            return Err(Error::UnexpectedMessageStatus(
+                responses[2].message.header.status,
+            ));
         }
         Ok(())
     }
@@ -872,8 +918,8 @@ impl Client {
         if file_id == smb_msg::FileId::EMPTY {
             return;
         }
-        if let Err(e) = crate::resource::ResourceHandle::send_close_external(file_id, &handler)
-            .await
+        if let Err(e) =
+            crate::resource::ResourceHandle::send_close_external(file_id, &handler).await
         {
             tracing::warn!(
                 path = label,

--- a/crates/smb/src/connection.rs
+++ b/crates/smb/src/connection.rs
@@ -19,8 +19,8 @@ use rand::RngCore;
 use rand::rngs::OsRng;
 use smb_dtyp::*;
 use smb_msg::{
-    Command, RequestContent, Response, ResponseContent, negotiate::*,
-    oplock::LeaseBreakAck, smb1::SMB1NegotiateMessage,
+    Command, RequestContent, Response, ResponseContent, negotiate::*, oplock::LeaseBreakAck,
+    smb1::SMB1NegotiateMessage,
 };
 use smb_transport::*;
 use std::cmp::max;
@@ -583,9 +583,7 @@ impl Connection {
     /// Subscribe to lease-break notifications received on this connection.
     /// See [`ConnectionMessageHandler::subscribe_lease_breaks`] for semantics.
     #[cfg(feature = "async")]
-    pub fn subscribe_lease_breaks(
-        &self,
-    ) -> tokio::sync::broadcast::Receiver<LeaseBreakEvent> {
+    pub fn subscribe_lease_breaks(&self) -> tokio::sync::broadcast::Receiver<LeaseBreakEvent> {
         self.handler.subscribe_lease_breaks()
     }
 
@@ -604,10 +602,7 @@ impl Connection {
 
     /// Look up a cached lease slot by path; `None` when absent.
     #[maybe_async]
-    pub async fn peek_lease_slot(
-        &self,
-        path: &str,
-    ) -> crate::Result<Option<Arc<LeaseSlot>>> {
+    pub async fn peek_lease_slot(&self, path: &str) -> crate::Result<Option<Arc<LeaseSlot>>> {
         self.handler.peek_lease_slot(path).await
     }
 
@@ -624,7 +619,12 @@ impl Connection {
         wants_directory: bool,
     ) -> crate::Result<Option<Arc<LeaseSlot>>> {
         self.handler
-            .try_acquire_lease(path, requested_access, requested_disposition, wants_directory)
+            .try_acquire_lease(
+                path,
+                requested_access,
+                requested_disposition,
+                wants_directory,
+            )
             .await
     }
 
@@ -632,10 +632,7 @@ impl Connection {
     /// See [`ConnectionMessageHandler::take_lease_for_evict`] for the
     /// race-free contract.
     #[maybe_async]
-    pub async fn take_lease_for_evict(
-        &self,
-        path: &str,
-    ) -> crate::Result<Option<LeaseEviction>> {
+    pub async fn take_lease_for_evict(&self, path: &str) -> crate::Result<Option<LeaseEviction>> {
         self.handler.take_lease_for_evict(path).await
     }
 
@@ -682,11 +679,37 @@ impl Connection {
     /// and validating each response's status code.
     ///
     /// On success returns `responses.len() == msgs.len()` in input order.
+    ///
+    /// **Size budget:** the whole chain (headers + bodies + 8-byte
+    /// alignment padding between members) goes out as one transport
+    /// write, which the server's NetBIOS-layer reader caps at the
+    /// negotiated `max_transact_size`. Callers should keep the sum of
+    /// per-member serialized sizes well below
+    /// `conn.conn_info().unwrap().negotiation.max_transact_size`
+    /// (typically 1 MiB on modern Windows / NetApp / Samba). Going
+    /// over yields `STATUS_INVALID_PARAMETER` or a torn connection
+    /// depending on the server. There is no client-side enforcement
+    /// today — adding one would require pre-serializing each member
+    /// twice, which defeats the point of the single-write path.
     #[maybe_async]
     pub async fn send_compound(
         &self,
         mut msgs: Vec<OutgoingMessage>,
     ) -> crate::Result<Vec<IncomingMessage>> {
+        // CancelRequest has its own bespoke path inside the single-message
+        // `sendo` (it reuses an already-allocated message_id and skips
+        // `process_sequence_outgoing`). Bundling it into a compound chain
+        // would either re-allocate its message_id — silently breaking the
+        // cancel target — or skip the per-member accounting we run below.
+        // Reject up front rather than letting either failure mode bite.
+        for (i, m) in msgs.iter().enumerate() {
+            if m.message.content.as_cancel().is_ok() {
+                return Err(Error::InvalidArgument(format!(
+                    "send_compound: member {i} is a CancelRequest, which is not \
+                     supported in compound chains; cancel must be sent on its own"
+                )));
+            }
+        }
         let priority_value = match self.handler.conn_info.get() {
             Some(neg_info) => match neg_info.negotiation.dialect_rev {
                 Dialect::Smb0311 => 1,
@@ -788,8 +811,7 @@ pub(crate) struct ConnectionMessageHandler {
 impl ConnectionMessageHandler {
     fn new(client_guid: Guid, credits_backlog: Option<u16>) -> ConnectionMessageHandler {
         #[cfg(feature = "async")]
-        let (lease_event_tx, _) =
-            tokio::sync::broadcast::channel(LEASE_BREAK_CHANNEL_CAPACITY);
+        let (lease_event_tx, _) = tokio::sync::broadcast::channel(LEASE_BREAK_CHANNEL_CAPACITY);
 
         ConnectionMessageHandler {
             client_guid,
@@ -840,6 +862,18 @@ impl ConnectionMessageHandler {
             if live == 0 && prev.file_id != smb_msg::FileId::EMPTY {
                 let file_id = prev.file_id;
                 let handler = prev.proto.handler.clone();
+                // The spawned task captures the `handler` chain
+                // (ResourceMessageHandle -> TreeMessageHandle ->
+                // SessionMessageHandler) by Arc clone, but NOT this
+                // ConnectionMessageHandler itself. If the Connection
+                // races into Drop before the spawn runs, its
+                // `worker.stop()` (in Connection::Drop) will complete
+                // first and send_close_external will see a stopped
+                // worker — at worst we lose this displaced FileId,
+                // which the session-disconnect garbage-collects anyway.
+                // The spawn does *not* extend the Connection's lifetime;
+                // tying it to Connection would require Arc'ing the
+                // handler chain back up, which we explicitly avoid.
                 tokio::spawn(async move {
                     if let Err(e) =
                         crate::resource::ResourceHandle::send_close_external(file_id, &handler)
@@ -870,10 +904,7 @@ impl ConnectionMessageHandler {
     /// [`Self::try_acquire_lease`] instead so the bump is atomic with the
     /// lookup against concurrent evictions.
     #[maybe_async]
-    pub async fn peek_lease_slot(
-        &self,
-        path: &str,
-    ) -> crate::Result<Option<Arc<LeaseSlot>>> {
+    pub async fn peek_lease_slot(&self, path: &str) -> crate::Result<Option<Arc<LeaseSlot>>> {
         Ok(self.lease_table.lock().await?.get(path).cloned())
     }
 
@@ -916,10 +947,7 @@ impl ConnectionMessageHandler {
     ///
     /// Returns `None` when `path` had no entry.
     #[maybe_async]
-    pub async fn take_lease_for_evict(
-        &self,
-        path: &str,
-    ) -> crate::Result<Option<LeaseEviction>> {
+    pub async fn take_lease_for_evict(&self, path: &str) -> crate::Result<Option<LeaseEviction>> {
         use std::sync::atomic::Ordering;
         let mut table = self.lease_table.lock().await?;
         let Some(slot) = table.remove(path) else {
@@ -934,7 +962,10 @@ impl ConnectionMessageHandler {
             needs_wire_close,
             "Lease slot tombstoned and removed from table",
         );
-        Ok(Some(LeaseEviction { slot, needs_wire_close }))
+        Ok(Some(LeaseEviction {
+            slot,
+            needs_wire_close,
+        }))
     }
 
     /// Phase C.5 idle sweep: walk the lease table, tombstone every slot
@@ -980,7 +1011,10 @@ impl ConnectionMessageHandler {
                     needs_wire_close,
                     "Idle lease slot tombstoned and removed",
                 );
-                out.push(LeaseEviction { slot, needs_wire_close });
+                out.push(LeaseEviction {
+                    slot,
+                    needs_wire_close,
+                });
             }
         }
         Ok(out)
@@ -992,7 +1026,6 @@ impl ConnectionMessageHandler {
     /// the broadcast channel doesn't exist in sync builds.
     #[cfg(feature = "async")]
     fn start_lease_break_listener(self: &Arc<Self>) {
-        use std::sync::atomic::Ordering;
         let mut rx = self.lease_event_tx.subscribe();
         let self_clone = self.clone();
         let stop = self.stop_notifications.clone();
@@ -1031,9 +1064,6 @@ impl ConnectionMessageHandler {
                 }
             }
             tracing::debug!("Lease break listener task stopped.");
-            // Suppress unused warning when the underlying ordering import
-            // isn't needed by simpler future code paths.
-            let _ = Ordering::Relaxed;
         });
     }
 
@@ -1112,9 +1142,7 @@ impl ConnectionMessageHandler {
     /// the subscriber's cache invalidation is delayed, never that the
     /// protocol is left in a bad state.
     #[cfg(feature = "async")]
-    pub fn subscribe_lease_breaks(
-        &self,
-    ) -> tokio::sync::broadcast::Receiver<LeaseBreakEvent> {
+    pub fn subscribe_lease_breaks(&self) -> tokio::sync::broadcast::Receiver<LeaseBreakEvent> {
         self.lease_event_tx.subscribe()
     }
 

--- a/crates/smb/src/connection/transformer.rs
+++ b/crates/smb/src/connection/transformer.rs
@@ -244,16 +244,35 @@ impl Transformer {
         //    the padded buffer. Signing must therefore happen AFTER
         //    padding so the HMAC input matches what the receiver
         //    re-hashes during verification.
-        for i in 0..last {
-            let aligned = (member_bufs[i].len() + 7) & !7usize;
-            member_bufs[i].resize(aligned, 0);
+        for buf in member_bufs.iter_mut().take(last) {
+            let aligned = (buf.len() + 7) & !7usize;
+            buf.resize(aligned, 0);
         }
 
         // 4. Sign each member if signing is requested (per-member, over
         //    that member's padded bytes). We snapshot the signer once
         //    and reuse it for each member (MessageSigner clone is cheap
         //    — no heap alloc).
+        //
+        // Sign policy is chain-wide: the first member's `signed` flag is
+        // the source of truth. We *also* enforce that every member
+        // agrees with it — mixing signed and unsigned members in a
+        // single chain produces a payload the server will reject as
+        // soon as it verifies any member's signature (signed members
+        // need a real signature, unsigned ones must carry the all-zero
+        // sentinel). Catching this here yields a clearer error than the
+        // server-side STATUS_ACCESS_DENIED that would otherwise come back.
         let should_sign = msgs[0].message.header.flags.signed();
+        if msgs
+            .iter()
+            .any(|m| m.message.header.flags.signed() != should_sign)
+        {
+            return Err(crate::Error::InvalidArgument(
+                "compound chain has inconsistent `signed` flags across members; \
+                 all members must opt in or opt out together"
+                    .to_string(),
+            ));
+        }
         if should_sign {
             let session_id = msgs[0].message.header.session_id;
             let signer = self
@@ -280,6 +299,21 @@ impl Transformer {
                 // After sign_message, iov[0] holds the buffer with the signature
                 // written back into the header. Move it back into member_bufs
                 // without copying (IoVecBuf::Owned -> Vec via mem::take).
+                //
+                // We rely on the signer leaving the IoVec as a single owned
+                // segment (sign_message writes the signature back into the
+                // header bytes that live in iov[0] — no splitting). If a
+                // future signer change starts appending segments, only
+                // iov[0] would be taken back here and the trailing bytes
+                // would silently drop on the floor. Guard against that
+                // regression with an explicit length check.
+                if iov.len() != 1 {
+                    return Err(crate::Error::InvalidState(format!(
+                        "signer split compound member buffer into {} segments; \
+                         exactly 1 expected",
+                        iov.len()
+                    )));
+                }
                 match &mut iov[0] {
                     smb_transport::IoVecBuf::Owned(v) => {
                         member_bufs[i] = std::mem::take(v);
@@ -437,10 +471,7 @@ impl Transformer {
     /// non-compound case). Member order matches the on-wire order, which the
     /// server is required to preserve relative to the request chain (MS-SMB2
     /// 3.3.5.2.7).
-    pub async fn transform_incoming_all(
-        &self,
-        data: Bytes,
-    ) -> crate::Result<Vec<IncomingMessage>> {
+    pub async fn transform_incoming_all(&self, data: Bytes) -> crate::Result<Vec<IncomingMessage>> {
         let message = Response::try_from(data.as_ref())?;
         let mut form = MessageForm::default();
 

--- a/crates/smb/src/connection/worker/parallel/base.rs
+++ b/crates/smb/src/connection/worker/parallel/base.rs
@@ -126,10 +126,7 @@ where
         }
         // Snapshot ids before consuming `msgs` so we can return them as
         // SendMessageResult after the transform.
-        let ids: Vec<u64> = msgs
-            .iter()
-            .map(|m| m.message.header.message_id)
-            .collect();
+        let ids: Vec<u64> = msgs.iter().map(|m| m.message.header.message_id).collect();
 
         let raw = self.transformer.transform_outgoing_compound(msgs).await?;
         tracing::trace!(

--- a/crates/smb/src/lease.rs
+++ b/crates/smb/src/lease.rs
@@ -58,8 +58,14 @@ pub struct LeaseBreakEvent {
     /// 35-second timeout. `false` indicates the server is just informing
     /// us of an unconditional downgrade; no reply is required.
     pub ack_required: bool,
-    /// Wall-clock instant the client received the notification, used for
-    /// observability and to drive ack-timeout backstops in Phase C.
+    /// Wall-clock instant the client received the notification. Today
+    /// this is purely observational (surfaced in tracing on the
+    /// listener task); kept on the event so the future ack-timeout
+    /// monitor can stamp "how long ago did this fire" without
+    /// re-snapshotting an Instant per subscriber.
+    // TODO: feed an explicit ack-timeout backstop monitor when one
+    // exists. The 35s window from MS-SMB2 2.2.23.2 is currently
+    // bounded only by the connection-wide notify task latency.
     pub received_at: Instant,
 }
 
@@ -121,6 +127,32 @@ pub(crate) struct ResourceProto {
 ///
 /// Until both conditions are met, the FileId stays live on the server and
 /// new Opens against the same path hit the cache for free.
+///
+/// # Lock ordering (load-bearing — read before adding a third locker)
+///
+/// Three locks may be held concurrently across this type and the
+/// per-connection `lease_table`:
+///
+/// 1. `ConnectionMessageHandler::lease_table` (outer; `Mutex<HashMap<…>>`).
+/// 2. `LeaseSlot::granted_state` (`RwLock<LeaseState>`).
+/// 3. `LeaseSlot::last_used` (`RwLock<Instant>`).
+///
+/// They MUST be acquired in that order. The existing call sites already
+/// obey it:
+/// * `apply_lease_break` takes `lease_table.lock()`, then writes
+///   `granted_state` while still holding the outer lock.
+/// * `try_acquire_for_reuse` is called *inside* `try_acquire_lease`'s
+///   `lease_table.lock()` guard and only reads `granted_state` /
+///   writes `last_used` after that.
+/// * `take_lease_for_evict` / `sweep_idle_leases` only touch atomic
+///   fields after removing the entry from the table, so they don't
+///   re-enter the inner locks.
+///
+/// Adding a fourth path that, say, reads `granted_state` first and then
+/// `lease_table` would invert order #1 ↔ #2 and risk a deadlock under
+/// concurrent break + reuse traffic. When in doubt, gate the new path
+/// through `Connection::try_acquire_lease` or `take_lease_for_evict`
+/// rather than holding the inner RwLocks directly.
 pub struct LeaseSlot {
     /// The file path (relative to the share root) the lease was opened
     /// against. Used as the lookup key inside the per-connection table

--- a/crates/smb/src/resource.rs
+++ b/crates/smb/src/resource.rs
@@ -206,7 +206,10 @@ impl Resource {
             match &grant {
                 Some(g) => tracing::debug!(
                     "Lease granted for '{}': key={:#034x}, state={:?}, epoch={}",
-                    name, g.key, g.state, g.epoch
+                    name,
+                    g.key,
+                    g.state,
+                    g.epoch
                 ),
                 None => tracing::debug!(
                     "Lease requested for '{}' but server did not grant one",
@@ -308,11 +311,22 @@ impl Resource {
     /// atomically with the eligibility check.
     pub(crate) fn reuse_from_slot(slot: Arc<LeaseSlot>) -> Resource {
         let proto = slot.proto.clone();
-        let granted_state = slot
-            .granted_state
-            .read()
-            .map(|s| *s)
-            .unwrap_or_else(|p| *p.into_inner());
+        // A poisoned RwLock here means a previous writer panicked while
+        // updating `granted_state` (e.g. inside `apply_lease_break`).
+        // The last-written value is still safe to read for cache-hit
+        // semantics — we just lose visibility into the panic. Surface
+        // it at WARN so operators see the chain of events instead of a
+        // silent state corruption.
+        let granted_state = match slot.granted_state.read() {
+            Ok(s) => *s,
+            Err(p) => {
+                tracing::warn!(
+                    path = %slot.path,
+                    "LeaseSlot.granted_state RwLock was poisoned; reusing last-written state",
+                );
+                *p.into_inner()
+            }
+        };
 
         let handle = ResourceHandle {
             name: slot.path.clone(),
@@ -1357,15 +1371,19 @@ mod tests {
 
     #[test]
     fn file_create_args_with_lease_builder() {
-        let args = FileCreateArgs::make_open_existing(FileAccessMask::new().with_generic_read(true))
-            .with_lease(RequestLease::RqLsReqv2(RequestLeaseV2 {
-                lease_key: 1,
-                lease_state: make_state(true, true, false),
-                lease_flags: LeaseFlags::new(),
-                parent_lease_key: 0,
-                epoch: 0,
-            }));
-        assert!(args.lease_request.is_some(), "with_lease should populate the field");
+        let args =
+            FileCreateArgs::make_open_existing(FileAccessMask::new().with_generic_read(true))
+                .with_lease(RequestLease::RqLsReqv2(RequestLeaseV2 {
+                    lease_key: 1,
+                    lease_state: make_state(true, true, false),
+                    lease_flags: LeaseFlags::new(),
+                    parent_lease_key: 0,
+                    epoch: 0,
+                }));
+        assert!(
+            args.lease_request.is_some(),
+            "with_lease should populate the field"
+        );
         assert!(matches!(
             args.lease_request.as_ref().unwrap(),
             RequestLease::RqLsReqv2(_)
@@ -1375,6 +1393,9 @@ mod tests {
     #[test]
     fn file_create_args_default_has_no_lease() {
         let args = FileCreateArgs::default();
-        assert!(args.lease_request.is_none(), "default must not request a lease");
+        assert!(
+            args.lease_request.is_none(),
+            "default must not request a lease"
+        );
     }
 }

--- a/crates/smb/src/resource/directory.rs
+++ b/crates/smb/src/resource/directory.rs
@@ -89,7 +89,9 @@ impl Directory {
                 )));
             }
             Err(e @ Error::UnexpectedMessageStatus(Status::U32_INVALID_INFO_CLASS)) => {
-                tracing::debug!("Error querying directory (server does not support this info class): {e}");
+                tracing::debug!(
+                    "Error querying directory (server does not support this info class): {e}"
+                );
                 return Err(e);
             }
             Err(e) => {

--- a/crates/smb/src/session/authenticator.rs
+++ b/crates/smb/src/session/authenticator.rs
@@ -69,9 +69,8 @@ impl Authenticator {
         // Use the first 16 bytes of the session key.
         let key_info = self.ssp.query_context_session_key()?;
         let k = &key_info.session_key.as_ref()[..16];
-        k.try_into().map_err(|_| {
-            Error::InvalidState("Session key is shorter than 16 bytes.".to_string())
-        })
+        k.try_into()
+            .map_err(|_| Error::InvalidState("Session key is shorter than 16 bytes.".to_string()))
     }
 
     fn make_sspi_target_name(server_fqdn: &str) -> String {

--- a/crates/smb/src/session/channel.rs
+++ b/crates/smb/src/session/channel.rs
@@ -60,6 +60,28 @@ impl Channel {
         let session = state.session.read().await?;
         session.allow_unsigned()
     }
+
+    /// Returns `true` when the session requires every outgoing request to be
+    /// encrypted (either the session flags carry `encrypt_data` or the
+    /// connection config forces it).
+    ///
+    /// Mirrors the check used inside [`ChannelMessageHandler::sendo`]: when
+    /// `should_encrypt()` is `true`, the single-message path sets
+    /// `msg.encrypt = true` instead of merely signing. Callers that build
+    /// SMB2 compound chains directly (e.g. P2.b) must inspect this *before*
+    /// going through the worker, because the compound transformer does not
+    /// yet support per-member encryption and would otherwise leak the
+    /// compound's headers/body in cleartext on an encryption-required
+    /// session.
+    ///
+    /// Errors with `InvalidState` when the underlying session has not
+    /// reached the Ready state, matching `SessionInfo::should_encrypt`.
+    #[maybe_async]
+    pub async fn should_encrypt(&self) -> crate::Result<bool> {
+        let state = self.handler.session_state.read().await?;
+        let session = state.session.read().await?;
+        session.should_encrypt()
+    }
 }
 
 /// Message handler a specific channel.

--- a/crates/smb/src/tree.rs
+++ b/crates/smb/src/tree.rs
@@ -203,7 +203,9 @@ impl Tree {
     /// Used by the lease cache (Phase C) so cache hits can match opens
     /// against the same tree the original Create was issued on.
     pub fn tree_id(&self) -> u32 {
-        self.handler.tree_id.load(std::sync::atomic::Ordering::Relaxed)
+        self.handler
+            .tree_id
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Borrow the tree's underlying `Upstream` handler reference.

--- a/crates/smb/tests/lease.rs
+++ b/crates/smb/tests/lease.rs
@@ -57,7 +57,9 @@ async fn test_lease_request_create_new() -> smb::Result<()> {
     // a server without `caps.leasing()` is expected to return None, and we
     // skip the positive assertion instead of treating it as a failure.
     let conn = client.get_connection(share_path.server()).await?;
-    let info = conn.conn_info().expect("share_connect completed → negotiated");
+    let info = conn
+        .conn_info()
+        .expect("share_connect completed → negotiated");
     let server_supports_leasing = info.negotiation.caps.leasing();
     tracing::info!(
         "Negotiated: dialect={:?}, leasing={}, multi_channel={}",
@@ -118,7 +120,10 @@ async fn test_no_lease_request_has_no_grant() -> smb::Result<()> {
     let (client, share_path) = make_server_connection(&share, None).await?;
 
     let args = FileCreateArgs::make_overwrite(Default::default(), Default::default());
-    assert!(args.lease_request.is_none(), "control: args must have no lease");
+    assert!(
+        args.lease_request.is_none(),
+        "control: args must have no lease"
+    );
 
     let file = client
         .create_file(&share_path.with_path("lease_phase_a_no_lease.txt"), &args)
@@ -182,8 +187,8 @@ async fn test_lease_break_notify_fanned_out() -> smb::Result<()> {
         parent_lease_key: 0,
         epoch: 0,
     });
-    let args_a = FileCreateArgs::make_overwrite(Default::default(), Default::default())
-        .with_lease(lease);
+    let args_a =
+        FileCreateArgs::make_overwrite(Default::default(), Default::default()).with_lease(lease);
     let file_a = client_a
         .create_file(&path, &args_a)
         .await?
@@ -292,7 +297,10 @@ async fn test_lease_slot_inserted_on_create() -> smb::Result<()> {
         .peek_lease_slot(path_rel)
         .await?
         .expect("slot must be reachable by path");
-    assert_eq!(slot.lease_key, grant.key, "slot's lease_key must echo the grant");
+    assert_eq!(
+        slot.lease_key, grant.key,
+        "slot's lease_key must echo the grant"
+    );
     assert_eq!(
         slot.refcount.load(std::sync::atomic::Ordering::Relaxed),
         1,
@@ -448,11 +456,15 @@ async fn test_lease_cache_hit_reuses_file_id() -> smb::Result<()> {
         .await?
         .expect("deferred close must leave the slot in the cache");
     assert!(
-        !slot_after_close.tombstoned.load(std::sync::atomic::Ordering::Acquire),
+        !slot_after_close
+            .tombstoned
+            .load(std::sync::atomic::Ordering::Acquire),
         "no break happened, slot must still be alive (not tombstoned)",
     );
     assert_eq!(
-        slot_after_close.refcount.load(std::sync::atomic::Ordering::Acquire),
+        slot_after_close
+            .refcount
+            .load(std::sync::atomic::Ordering::Acquire),
         0,
         "refcount returns to 0 after close, but slot stays cached",
     );
@@ -461,10 +473,9 @@ async fn test_lease_cache_hit_reuses_file_id() -> smb::Result<()> {
     // returned Resource must reuse the cached FileId — no new Create RT
     // hit the wire. We assert FileId equality as the wire-observable
     // proof.
-    let args_reopen = FileCreateArgs::make_open_existing(
-        FileAccessMask::new().with_generic_all(true),
-    )
-    .with_lease(make_lease_request());
+    let args_reopen =
+        FileCreateArgs::make_open_existing(FileAccessMask::new().with_generic_all(true))
+            .with_lease(make_lease_request());
     let file_second = client
         .create_file(&unc, &args_reopen)
         .await?
@@ -476,7 +487,9 @@ async fn test_lease_cache_hit_reuses_file_id() -> smb::Result<()> {
         "cache hit must reuse the original FileId (saving a Create RT)",
     );
     assert_eq!(
-        slot_after_close.refcount.load(std::sync::atomic::Ordering::Acquire),
+        slot_after_close
+            .refcount
+            .load(std::sync::atomic::Ordering::Acquire),
         1,
         "second open bumps refcount back to 1",
     );
@@ -691,8 +704,8 @@ async fn test_flush_idle_leases_sweeps_old_slots() -> smb::Result<()> {
 ))]
 #[serial]
 async fn test_compound_set_basic_info() -> smb::Result<()> {
-    use smb::{FileAccessMask, FileBasicInformation};
     use smb::binrw_util::file_time::FileTime;
+    use smb::{FileAccessMask, FileBasicInformation};
 
     let share = smb_tests_share();
     let (client, share_path) = make_server_connection(&share, None).await?;
@@ -737,11 +750,7 @@ async fn test_compound_set_basic_info() -> smb::Result<()> {
         .await?
         .into_file()
         .expect("must be file");
-    let queried: FileBasicInformation = v
-        .handle()
-        .query_info()
-        .await
-        .expect("query basic info");
+    let queried: FileBasicInformation = v.handle().query_info().await.expect("query basic info");
     assert_eq!(
         *queried.last_write_time, *target_mtime,
         "compound SetInfo's last_write_time must be visible after the chain's Close commits",
@@ -753,8 +762,7 @@ async fn test_compound_set_basic_info() -> smb::Result<()> {
     v.close().await?;
 
     // Cleanup
-    let cleanup_args =
-        FileCreateArgs::make_open_existing(FileAccessMask::new().with_delete(true));
+    let cleanup_args = FileCreateArgs::make_open_existing(FileAccessMask::new().with_delete(true));
     let c = client
         .create_file(&unc, &cleanup_args)
         .await?
@@ -796,7 +804,8 @@ async fn test_client_default_lease_state_auto_injects() -> smb::Result<()> {
     );
 
     let server = std::env::var("SMB_RUST_TESTS_SERVER").unwrap_or_else(|_| "127.0.0.1".to_string());
-    let user = std::env::var("SMB_RUST_TESTS_USER_NAME").unwrap_or_else(|_| "LocalAdmin".to_string());
+    let user =
+        std::env::var("SMB_RUST_TESTS_USER_NAME").unwrap_or_else(|_| "LocalAdmin".to_string());
     let password =
         std::env::var("SMB_RUST_TESTS_PASSWORD").unwrap_or_else(|_| "123456".to_string());
     let client = Client::new(config);
@@ -839,9 +848,8 @@ async fn test_client_default_lease_state_auto_injects() -> smb::Result<()> {
     file_first.close().await?;
 
     // Second open also without explicit lease — must hit the cache.
-    let args_reopen = FileCreateArgs::make_open_existing(
-        FileAccessMask::new().with_generic_all(true),
-    );
+    let args_reopen =
+        FileCreateArgs::make_open_existing(FileAccessMask::new().with_generic_all(true));
     let file_second = client
         .create_file(&unc, &args_reopen)
         .await?

--- a/smb-cli/src/cli.rs
+++ b/smb-cli/src/cli.rs
@@ -177,6 +177,7 @@ impl Cli {
                 multichannel: self.multichannel.into(),
                 ..Default::default()
             },
+            ..Default::default()
         })
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #2 — addresses all findings from a five-axis code review
of the merged compound chain (P2.b) and Lease A–D series. Three logically
separated commits:

1. **`style(smb): apply cargo fmt across workspace`** — pure formatting
   noise that accumulated across the lease/compound work. `git diff -w`
   verifies the diff is whitespace-only.
2. **`fix(smb-cli): default-spread ClientConfig to absorb new fields`** —
   restores `cargo check --workspace`. The Lease Phase D commit added two
   required public fields to `ClientConfig` (`default_lease_state`,
   `lease_key_salt`) without `..Default::default()` in any caller, so the
   in-workspace CLI stopped compiling — and any downstream caller using
   struct-literal construction is equally broken.
3. **`fix(smb): code-review pass — compound + lease hardening`** — the
   batch of correctness, security, and robustness fixes below.

## Fix breakdown

| Pri | Tag | Change |
|---|---|---|
| Critical | C2 | `compound_set_basic_info` previously sent only-signed, plaintext frames on encryption-required sessions, silently bypassing the session's encryption policy. Adds `Channel::should_encrypt()` and bails out with `UnsupportedOperation` when the session requires encryption. |
| High | H1 | `derive_lease_key` now uses `siphasher::sip128::SipHasher24` (version-stable, keyed) instead of `DefaultHasher`, whose algorithm is explicitly unstable across Rust versions. Load-bearing for callers that pin `lease_key_salt`. |
| High | H2 | `transform_outgoing_compound` rejects chains whose members disagree on `flags.signed()` — previously msgs[0] alone decided. Partial-sign chains would have produced `STATUS_ACCESS_DENIED` with no clear cause. |
| Medium | M1 | Close failure in `compound_set_basic_info` is now `Err(UnexpectedMessageStatus)` instead of WARN-and-Ok, so batch callers can detect server-side handle leaks. |
| Medium | M2 | `Connection::send_compound` rejects `CancelRequest` members at the gate (cancel has its own message-id reuse path). |
| Medium | M3 | `LeaseSlot` doc captures the load-bearing lock ordering: `lease_table` → `granted_state` → `last_used`. |
| Medium | M4 | `insert_lease_slot` spawn-Close comment clarifies it does not extend the Connection's lifetime. |
| Medium | M5 | Explicit `iov.len() == 1` check after `sign_message` so a future signer split fails loudly instead of dropping bytes. |
| Low | L1 | clippy `needless_range_loop` cleared on `transformer.rs:247`. |
| Low | L3 | `reuse_from_slot` poisoned-RwLock branch emits `tracing::warn` instead of silently swallowing. |
| Low | L4 | `compound_set_basic_info` `share_access` drops `delete` (not needed for SetInfo+Close); doc notes fixed-policy nature. |
| Low | L5 | Dead `let _ = Ordering::Relaxed;` filler and matching `use` removed. |
| Low | L6 | `Connection::send_compound` doc gains size-budget paragraph pointing at `max_transact_size`. |
| Low | L7 | `LeaseBreakEvent.received_at` doc clarifies current observational role + adds ack-timeout monitor TODO. |

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo clippy --workspace --no-deps` — 0 warnings
- [x] `cargo test -p smb --lib` — 16 passed
- [x] `cargo test -p smb-msg` — 118 passed + 1 doctest
- [x] `cargo fmt --check` — clean
- [ ] Live-server regression: re-run the 10 lease integration tests against 10.131.7.203
- [ ] terrasync-rs end-to-end sync + integrity check (M1 in particular changes a previously-Ok return into Err)

🤖 Generated with [Claude Code](https://claude.com/claude-code)