### PR TITLE
refactor(transformer): own connection preauth integrity hash + Protection enum (rollup of #5)

### DIFF
--- a/crates/smb/src/connection.rs
+++ b/crates/smb/src/connection.rs
@@ -501,7 +501,7 @@ impl Connection {
             .map_err(|_| Error::InvalidState("Worker already set.".to_string()))?;
 
         // Negotiate SMB2
-        let info = self._negotiate_smb2(server_address).await?;
+        let info = Arc::new(self._negotiate_smb2(server_address).await?);
 
         self.handler
             .worker
@@ -535,7 +535,7 @@ impl Connection {
 
         self.handler
             .conn_info
-            .set(Arc::new(info))
+            .set(info)
             .map_err(|_| Error::InvalidState("Connection info already set.".to_string()))?;
 
         tracing::debug!("Negotiation successful");

--- a/crates/smb/src/connection/preauth_hash.rs
+++ b/crates/smb/src/connection/preauth_hash.rs
@@ -6,9 +6,12 @@ pub type PreauthHashValue = [u8; 64];
 
 pub const SUPPORTED_ALGOS: &[HashAlgorithm] = &[HashAlgorithm::Sha512];
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum PreauthHashState {
     /// This state always transitions to itself, and calling `unwrap_final_hash` returns `None`.
+    /// Also the `Default` so that holders constructed before `negotiated()`
+    /// runs are in the safest possible state (no integrity tracking).
+    #[default]
     Unsupported,
 
     InProgress(PreauthHashValue),

--- a/crates/smb/src/connection/transformer.rs
+++ b/crates/smb/src/connection/transformer.rs
@@ -1,3 +1,4 @@
+use crate::connection::preauth_hash::{PreauthHashState, PreauthHashValue};
 use crate::session::{SessionAndChannel, SessionInfo};
 use crate::sync_helpers::*;
 use crate::{compression::*, msg_handler::*};
@@ -22,6 +23,18 @@ pub struct Transformer {
     sessions: RwLock<HashMap<u64, Arc<RwLock<SessionAndChannel>>>>,
 
     config: RwLock<TransformerConfig>,
+
+    /// Connection-level preauth integrity hash (SMB 3.1.1). The
+    /// transformer is the single authoritative owner per MS-SMB2
+    /// §3.1.4.2: ingested automatically from Negotiate / SessionSetup
+    /// plain bytes during `transform_outgoing` / `transform_incoming`,
+    /// and surfaced via [`Self::snapshot_preauth_finalized`] for
+    /// signing-key derivation during the final SessionSetup round.
+    ///
+    /// Empty before [`Self::negotiated`] runs; seeded from
+    /// `ConnectionInfo::preauth_hash` (which already includes the
+    /// Negotiate Req + Resp) at that point.
+    preauth_hash: Mutex<PreauthHashState>,
 }
 
 #[derive(Default, Debug)]
@@ -30,13 +43,19 @@ struct TransformerConfig {
     compress: Option<(Compressor, Decompressor)>,
 
     negotiated: bool,
+
+    /// Cached snapshot of the negotiated dialect/signing/encryption
+    /// parameters. Populated by [`Transformer::negotiated`] and read by
+    /// the setup-phase signing path so the transformer doesn't need to
+    /// re-borrow `ConnectionInfo` from the worker on every send.
+    conn_info: Option<Arc<ConnectionInfo>>,
 }
 
 #[maybe_async(AFIT)]
 impl Transformer {
     /// Notifies that the connection negotiation has been completed,
     /// with the given [`ConnectionInfo`].
-    pub async fn negotiated(&self, neg_info: &ConnectionInfo) -> crate::Result<()> {
+    pub async fn negotiated(&self, neg_info: &Arc<ConnectionInfo>) -> crate::Result<()> {
         {
             let config = self.config.read().await?;
             if config.negotiated {
@@ -55,9 +74,95 @@ impl Transformer {
             config.compress = compress;
         }
 
+        // Seed the connection-level preauth hash from the value the
+        // negotiator built out of the Negotiate Req + Resp wire bytes.
+        // From now on the transformer is the sole owner: all subsequent
+        // SessionSetup Req/Resp ingestion happens inside
+        // `transform_outgoing` / `transform_incoming`.
+        *self.preauth_hash.lock().await? = neg_info.preauth_hash.clone();
+
+        config.conn_info = Some(neg_info.clone());
         config.negotiated = true;
 
         Ok(())
+    }
+
+    /// Returns a clone of the current preauth hash, advanced to its
+    /// `Finished` form for key-derivation use. `Ok(None)` is returned
+    /// when the negotiated dialect doesn't support preauth integrity
+    /// (i.e. anything below SMB 3.1.1).
+    ///
+    /// This is the public surface for the session-setup driver: it
+    /// invokes this after the final SessionSetup Request has been
+    /// dispatched (the transformer auto-ingested the plain bytes during
+    /// `transform_outgoing`), and uses the value to derive the channel
+    /// SigningKey.
+    pub async fn snapshot_preauth_finalized(&self) -> crate::Result<Option<PreauthHashValue>> {
+        let snapshot = self.preauth_hash.lock().await?.clone();
+        match snapshot.finish()? {
+            PreauthHashState::Finished(v) => Ok(Some(v)),
+            PreauthHashState::Unsupported => Ok(None),
+            PreauthHashState::InProgress(_) => Err(crate::Error::InvalidState(
+                "PreauthHashState::finish() returned InProgress — should be unreachable".into(),
+            )),
+        }
+    }
+
+    /// Cached `ConnectionInfo` captured by `negotiated`. None before
+    /// negotiation completes. Used by the setup-phase signing path
+    /// (S4-T3) to derive the dialect / signing algorithm without
+    /// re-borrowing from the worker on every send.
+    #[allow(dead_code)] // wired up in S4-T3
+    async fn conn_info(&self) -> crate::Result<Option<Arc<ConnectionInfo>>> {
+        Ok(self.config.read().await?.conn_info.clone())
+    }
+
+    /// Derive a one-shot [`MessageSigner`] for the final SessionSetup
+    /// Request, using the snapshot of the preauth hash that already
+    /// includes this request's plain bytes (auto-ingested above) and
+    /// the GSS-supplied SessionKey provided by the setup driver.
+    ///
+    /// Mirrors `ChannelInfo::new`'s key derivation so the signer is
+    /// byte-identical to the one the server independently derives.
+    async fn derive_setup_phase_signer(
+        &self,
+        session_key: &crate::crypto::KeyToDerive,
+    ) -> crate::Result<crate::session::MessageSigner> {
+        let conn_info = self.conn_info().await?.ok_or_else(|| {
+            crate::Error::InvalidState(
+                "setup-phase signing requested before `negotiated` ran".into(),
+            )
+        })?;
+        let preauth_snapshot = self.snapshot_preauth_finalized().await?;
+        let channel_info = crate::session::ChannelInfo::new(
+            // The id only matters for in-session channel tracking; a
+            // setup-phase signer is anonymous (no session table entry
+            // yet), so any sentinel will do.
+            u32::MAX,
+            session_key,
+            &preauth_snapshot,
+            &conn_info,
+        )?;
+        Ok(channel_info.signer()?.clone())
+    }
+
+    /// MS-SMB2 §3.1.4.2: client-side rule for which **outgoing**
+    /// messages get folded into Connection.PreauthIntegrityHashValue.
+    fn participates_in_preauth_outgoing(header: &Header) -> bool {
+        matches!(header.command, Command::Negotiate | Command::SessionSetup)
+    }
+
+    /// MS-SMB2 §3.1.4.2: client-side rule for which **incoming**
+    /// messages get folded into the hash. Negotiate Response is always
+    /// included; SessionSetup Response only when it carries
+    /// MORE_PROCESSING_REQUIRED (i.e. it isn't the final ACK that
+    /// closes the chain).
+    fn participates_in_preauth_incoming(header: &Header) -> bool {
+        match header.command {
+            Command::Negotiate => true,
+            Command::SessionSetup => header.status == Status::MoreProcessingRequired as u32,
+            _ => false,
+        }
     }
 
     /// Notifies that a session has started.
@@ -348,11 +453,31 @@ impl Transformer {
         let session_id = msg.message.header.session_id;
 
         let mut outgoing_data = IoVec::default();
-        // Plain header + content
+        // Plain header + content (signature is still zero at this point —
+        // `sign_message` patches it back into the buffer below, after the
+        // preauth-hash ingest sees the unsigned bytes).
         {
             let buffer = outgoing_data.add_owned(Vec::with_capacity(Header::STRUCT_SIZE));
             msg.message.write(&mut Cursor::new(buffer))?;
         }
+
+        // Per MS-SMB2 §3.1.4.2, Negotiate Requests and *all*
+        // SessionSetup Requests participate in the connection-level
+        // preauth integrity hash. We ingest the plain (signature=0)
+        // bytes here so the hash is identical to what the server
+        // computes on receive. Doing it inside the transformer
+        // centralises the contract: the session-setup driver doesn't
+        // need to know which messages count.
+        if Self::participates_in_preauth_outgoing(&msg.message.header) {
+            if let Some(plain) = outgoing_data.first() {
+                let mut hash = self.preauth_hash.lock().await?;
+                // Clone-then-replace: if `next` errors we want to keep
+                // the previous hash state intact, not corrupt it to a
+                // default `Unsupported`.
+                *hash = hash.clone().next(plain)?;
+            }
+        }
+
         // Additional data, if any (zero-copy via Bytes)
         if let Some(data) = msg.additional_data.take() {
             if !data.is_empty() {
@@ -367,8 +492,17 @@ impl Transformer {
                 "Should not sign and encrypt at the same time!"
             );
 
-            let mut signer = self
-                ._with_channel(session_id, |session| {
+            let mut signer = if let Some(session_key) = msg.setup_phase_signing_key.take() {
+                // Setup-phase path: the final SessionSetup Request signs
+                // itself with a one-shot key derived from
+                // KDF(SessionKey, finalized preauth hash AFTER this
+                // request's plain bytes), per MS-SMB2 §3.2.4.1.7. No
+                // channel exists in `session_state` yet (it'll be
+                // installed by the driver immediately after dispatch
+                // for the response-verify path).
+                self.derive_setup_phase_signer(&session_key).await?
+            } else {
+                self._with_channel(session_id, |session| {
                     let channel_info =
                         session
                             .channel
@@ -383,7 +517,8 @@ impl Transformer {
 
                     Ok(channel_info.signer()?.clone())
                 })
-                .await?;
+                .await?
+            };
 
             signer.sign_message(&mut msg.message.header, &mut outgoing_data)?;
 
@@ -656,6 +791,19 @@ impl Transformer {
                 ));
             }
         };
+
+        // Per MS-SMB2 §3.1.4.2 fold qualifying responses into the
+        // connection-level preauth hash *before* signature verification:
+        // (a) so the Final SessionSetup Response we're about to verify
+        // sees the same hash the server used to derive its signing key,
+        // and (b) so future channel-binding setups picking up the
+        // snapshot see Negotiate Resp / intermediate SessionSetup Resp
+        // bytes included.
+        if Self::participates_in_preauth_incoming(&message.header) {
+            let mut hash = self.preauth_hash.lock().await?;
+            // Clone-then-replace; see `transform_outgoing` for rationale.
+            *hash = hash.clone().next(&raw)?;
+        }
 
         // Verify signature directly from raw bytes (no IoVec copy needed).
         if let Err(e) = self

--- a/crates/smb/src/connection/transformer.rs
+++ b/crates/smb/src/connection/transformer.rs
@@ -492,7 +492,9 @@ impl Transformer {
                 "Should not sign and encrypt at the same time!"
             );
 
-            let mut signer = if let Some(session_key) = msg.setup_phase_signing_key.take() {
+            let mut signer = if let Some(Protection::SnapshotKdfSign { session_key }) =
+                msg.security.take()
+            {
                 // Setup-phase path: the final SessionSetup Request signs
                 // itself with a one-shot key derived from
                 // KDF(SessionKey, finalized preauth hash AFTER this

--- a/crates/smb/src/connection/worker/worker_trait.rs
+++ b/crates/smb/src/connection/worker/worker_trait.rs
@@ -163,7 +163,7 @@ pub trait Worker: Sized + std::fmt::Debug {
     fn transformer(&self) -> &Transformer;
 
     #[maybe_async]
-    async fn negotaite_complete(&self, neg: &ConnectionInfo) {
+    async fn negotaite_complete(&self, neg: &Arc<ConnectionInfo>) {
         self.transformer().negotiated(neg).await.unwrap();
     }
 

--- a/crates/smb/src/msg_handler.rs
+++ b/crates/smb/src/msg_handler.rs
@@ -39,6 +39,16 @@ pub struct OutgoingMessage {
     /// code that needs to construct a pre-stamped, signed message goes
     /// through [`OutgoingMessage::into_signed_pre_prepared`].
     pub(crate) pre_processed: bool,
+
+    /// Internal: signals the transformer to take the "setup-phase
+    /// signing" code path for this message — derive a one-shot signer
+    /// from `(this key, finalized preauth hash after ingesting THIS
+    /// request's plain bytes)` and sign with it, instead of looking up
+    /// a cached channel signer from `session_state`. Used exclusively
+    /// for the final SessionSetup Request, where no channel exists in
+    /// the session table yet but MS-SMB2 §3.3.5.5.3 still requires the
+    /// request to be signed.
+    pub(crate) setup_phase_signing_key: Option<crate::crypto::KeyToDerive>,
 }
 
 impl OutgoingMessage {
@@ -52,6 +62,7 @@ impl OutgoingMessage {
             additional_data: None,
             channel_id: None,
             pre_processed: false,
+            setup_phase_signing_key: None,
         }
     }
 

--- a/crates/smb/src/msg_handler.rs
+++ b/crates/smb/src/msg_handler.rs
@@ -40,15 +40,35 @@ pub struct OutgoingMessage {
     /// through [`OutgoingMessage::into_signed_pre_prepared`].
     pub(crate) pre_processed: bool,
 
-    /// Internal: signals the transformer to take the "setup-phase
-    /// signing" code path for this message — derive a one-shot signer
-    /// from `(this key, finalized preauth hash after ingesting THIS
-    /// request's plain bytes)` and sign with it, instead of looking up
-    /// a cached channel signer from `session_state`. Used exclusively
-    /// for the final SessionSetup Request, where no channel exists in
-    /// the session table yet but MS-SMB2 §3.3.5.5.3 still requires the
-    /// request to be signed.
-    pub(crate) setup_phase_signing_key: Option<crate::crypto::KeyToDerive>,
+    /// Internal: explicit, sealed-at-construction safety policy. When
+    /// `Some`, the transformer dispatches on this *instead of*
+    /// inferring sign/encrypt from session state — eliminating the
+    /// class of bug where `ChannelMessageHandler::sendo` looks at
+    /// `session.state` to decide and gets it wrong (e.g. the
+    /// Windows-DC unsigned-final-request regression).
+    ///
+    /// Today only the SessionSetup driver populates this, for the
+    /// final SessionSetup Request. S5-T2 will extend the same
+    /// mechanism to the rest of the send paths and retire the
+    /// state-inference branch in `ChannelMessageHandler::sendo`.
+    pub(crate) security: Option<Protection>,
+}
+
+/// Explicit security treatment for an [`OutgoingMessage`].
+///
+/// Sealed at construction by the caller, so the transformer doesn't
+/// need to re-derive the choice from mutable session state at send
+/// time. See [`OutgoingMessage::security`] for the rationale.
+#[derive(Debug, Clone)]
+pub enum Protection {
+    /// Sign this request with a one-shot key derived from the given
+    /// GSS-supplied SessionKey and the transformer's currently
+    /// finalized preauth hash (after the request's own plain bytes
+    /// are ingested). Used exclusively for the final SessionSetup
+    /// Request — see MS-SMB2 §3.3.5.5.3.
+    SnapshotKdfSign {
+        session_key: crate::crypto::KeyToDerive,
+    },
 }
 
 impl OutgoingMessage {
@@ -62,7 +82,7 @@ impl OutgoingMessage {
             additional_data: None,
             channel_id: None,
             pre_processed: false,
-            setup_phase_signing_key: None,
+            security: None,
         }
     }
 

--- a/crates/smb/src/session.rs
+++ b/crates/smb/src/session.rs
@@ -5,7 +5,7 @@
 
 use crate::UncPath;
 use crate::connection::connection_info::ConnectionInfo;
-use crate::connection::preauth_hash::{PreauthHashState, PreauthHashValue};
+use crate::connection::preauth_hash::PreauthHashValue;
 use crate::connection::worker::Worker;
 use crate::{
     Error,

--- a/crates/smb/src/session/setup.rs
+++ b/crates/smb/src/session/setup.rs
@@ -23,10 +23,6 @@ where
 
     handler: Option<ChannelMessageHandler>,
 
-    /// should always be set; this is Option to allow moving it out during setup,
-    /// when it is being updated.
-    preauth_hash: Option<PreauthHashState>,
-
     result: Option<Arc<RwLock<SessionAndChannel>>>,
 
     authenticator: G,
@@ -85,7 +81,6 @@ where
             flags: None,
             result: None,
             handler: None,
-            preauth_hash: Some(conn_info.preauth_hash.clone()),
             authenticator,
             upstream,
             conn_info,
@@ -191,9 +186,10 @@ where
                 {
                     return Err(crate::error::SetupError::UnsignedFinalResponse.into());
                 }
-            } else {
-                self.next_preauth_hash(&response.raw)?;
             }
+            // Intermediate response preauth ingest is now done inside
+            // `Transformer::transform_incoming` (S4-T2); no driver-side
+            // bookkeeping needed.
 
             self.flags = Some(session_setup_response.session_flags);
             self.last_setup_response = Some(session_setup_response)
@@ -298,29 +294,20 @@ where
         }
     }
 
-    /// Never signed, so wire bytes == plain bytes (`signature = 0`),
-    /// and the preauth hash can be updated from `send_result.raw`
-    /// after the fact without diverging from the server's hash.
+    /// Never signed, so wire bytes == plain bytes (`signature = 0`).
+    /// The connection-level preauth hash is fed by
+    /// `Transformer::transform_outgoing` (S4-T2); the driver is hands-off.
     async fn send_intermediate_setup_request(
         &mut self,
         request: OutgoingMessage,
     ) -> crate::Result<SendMessageResult> {
-        let mut send_result = if let Some(handler) = self.handler.as_ref() {
+        if let Some(handler) = self.handler.as_ref() {
             tracing::trace!("setup loop: sending intermediate with channel handler");
-            handler.sendo(request).await?
+            handler.sendo(request).await
         } else {
             tracing::trace!("setup loop: sending intermediate with upstream handler");
-            self.upstream.sendo(request).await?
-        };
-
-        let raw_iovec = send_result.raw.as_mut().ok_or_else(|| {
-            Error::InvalidState("Send result raw data is missing.".to_string())
-        })?;
-        raw_iovec.consolidate();
-        self.next_preauth_hash(raw_iovec.first().ok_or_else(|| {
-            Error::InvalidState("Raw IoVec is empty after consolidation.".to_string())
-        })?)?;
-        Ok(send_result)
+            self.upstream.sendo(request).await
+        }
     }
 
     /// Final SessionSetup Request (the one carrying the GSS authenticator
@@ -328,21 +315,16 @@ where
     ///
     /// Per MS-SMB2 §3.3.5.5.3 the server **requires** this request to
     /// be signed on any non-anonymous SMB 3.x session (Windows DCs in
-    /// particular drop it silently otherwise). Per §3.2.4.1 the
-    /// SigningKey must be derived from the preauth hash *including*
-    /// this request's plain bytes — so we must serialize the request
-    /// once (with `signature = 0`) before computing the hash, then
-    /// have the transformer serialize it a second time to produce the
-    /// wire bytes it actually signs. Both serializations are
-    /// byte-identical (deterministic `binrw` output), so the
-    /// client-side and server-side hashes match.
+    /// particular drop it silently otherwise). The transformer owns
+    /// the preauth-hash plumbing: we just attach the GSS-derived
+    /// SessionKey to the outgoing message via `setup_phase_signing_key`,
+    /// and `Transformer::transform_outgoing` ingests the plain bytes,
+    /// derives a one-shot signer from the resulting finalized hash, and
+    /// signs in place — all in one pass.
     async fn send_final_setup_request(
         &mut self,
         mut request: OutgoingMessage,
     ) -> crate::Result<SendMessageResult> {
-        use binrw::prelude::*;
-        use std::io::Cursor;
-
         self.upstream
             .handler
             .prepare_outgoing(&mut request)
@@ -359,33 +341,29 @@ where
             .session_id;
         request.message.header.session_id = session_id;
 
-        let mut plain_bytes: Vec<u8> = Vec::with_capacity(256);
-        request
-            .message
-            .write(&mut Cursor::new(&mut plain_bytes))?;
+        request.setup_phase_signing_key = Some(self.session_key()?);
+        let mut request = request.into_signed_pre_prepared();
+        // Inhibit any future encryption attempt on this message (Sign
+        // and Encrypt are mutually exclusive per the transformer's
+        // own debug_assert).
+        request.encrypt = false;
 
-        self.next_preauth_hash(&plain_bytes)?;
-        self.preauth_hash = Some(
-            self.preauth_hash
-                .take()
-                .ok_or_else(|| {
-                    Error::InvalidState("Preauth hash is missing before finalize".to_string())
-                })?
-                .finish()?,
-        );
-
-        // Channel must be installed into session_state before dispatch:
-        // the transformer reads channel.signer from there to sign the
-        // request right after re-serializing it.
-        self.make_channel().await?;
-
-        let request = request.into_signed_pre_prepared();
         tracing::trace!(
             "setup loop: dispatching final signed SessionSetup msg_id={} session_id={:#x}",
             request.message.header.message_id,
             session_id
         );
-        self.upstream.handler.dispatch_outgoing(request).await
+        let result = self.upstream.handler.dispatch_outgoing(request).await?;
+
+        // Install the channel into session_state *after* dispatch so
+        // the receive path can verify the matching signed Response —
+        // the channel signer is derived from the same preauth hash the
+        // transformer used a moment ago (it's stable now: the
+        // SessionSetup Response with status=Success does NOT update
+        // the hash per MS-SMB2 §3.1.4.2).
+        self.make_channel().await?;
+
+        Ok(result)
     }
 
     /// Initializes the channel that is resulted from the current session setup.
@@ -396,10 +374,20 @@ where
         T::on_session_key_exchanged(self).await?;
         tracing::trace!("Session keys are set.");
 
+        // The preauth hash is owned by the transformer (S4-T1); snapshot
+        // its current finalized value to derive the channel SigningKey.
+        let preauth_snapshot = self
+            .upstream
+            .worker()
+            .ok_or_else(|| Error::InvalidState("Worker not available!".to_string()))?
+            .transformer()
+            .snapshot_preauth_finalized()
+            .await?;
+
         let channel_info = ChannelInfo::new(
             self.new_channel_id,
             &self.session_key()?,
-            &self.preauth_hash_value(),
+            &preauth_snapshot,
             self.conn_info,
         )?;
 
@@ -425,19 +413,16 @@ where
         self.authenticator.session_key()
     }
 
-    fn preauth_hash_value(&self) -> Option<PreauthHashValue> {
-        self.preauth_hash
-            .as_ref()
-            .and_then(|h| h.unwrap_final_hash().ok().flatten().copied())
-    }
-
-    fn next_preauth_hash(&mut self, data: &[u8]) -> crate::Result<&PreauthHashState> {
-        if let Some(hash) = self.preauth_hash.take() {
-            self.preauth_hash = Some(hash.next(data)?);
-        }
-        self.preauth_hash
-            .as_ref()
-            .ok_or_else(|| Error::InvalidState("Preauth hash is missing.".to_string()))
+    /// Snapshot the connection-level preauth hash from the transformer
+    /// (S4-T1). Used by `SmbSessionNew::on_session_key_exchanged` to
+    /// derive the per-session keys.
+    async fn preauth_hash_snapshot(&self) -> crate::Result<Option<PreauthHashValue>> {
+        self.upstream
+            .worker()
+            .ok_or_else(|| Error::InvalidState("Worker not available!".to_string()))?
+            .transformer()
+            .snapshot_preauth_finalized()
+            .await
     }
 
     pub fn upstream(&self) -> &'a ChannelUpstream {
@@ -618,7 +603,7 @@ impl SessionSetupProperties for SmbSessionNew {
             .await?
             .setup(
                 &setup.session_key()?,
-                &setup.preauth_hash_value(),
+                &setup.preauth_hash_snapshot().await?,
                 setup.conn_info,
             )
     }

--- a/crates/smb/src/session/setup.rs
+++ b/crates/smb/src/session/setup.rs
@@ -341,7 +341,9 @@ where
             .session_id;
         request.message.header.session_id = session_id;
 
-        request.setup_phase_signing_key = Some(self.session_key()?);
+        request.security = Some(crate::msg_handler::Protection::SnapshotKdfSign {
+            session_key: self.session_key()?,
+        });
         let mut request = request.into_signed_pre_prepared();
         // Inhibit any future encryption attempt on this message (Sign
         // and Encrypt are mutually exclusive per the transformer's

--- a/crates/smb/tests/conformance/transcripts.rs
+++ b/crates/smb/tests/conformance/transcripts.rs
@@ -144,6 +144,66 @@ pub fn session_setup_response_final(session_id: u64) -> Bytes {
     ))
 }
 
+/// Build a SessionSetup Response #2 (final round) reporting success
+/// **on an anonymous session** — `session_flags.is_null_session = true`.
+///
+/// MS-SMB2 §3.2.5.3.1 lets the driver accept an unsigned final
+/// response in this case (no SessionKey is derived, so signing isn't
+/// possible). Used by the `conformance_anonymous` test to verify that
+/// the SessionSetup path doesn't over-eagerly reject the success
+/// reply.
+pub fn session_setup_response_final_anonymous(session_id: u64) -> Bytes {
+    let content = SessionSetupResponse {
+        session_flags: SessionFlags::new().with_is_null_session(true),
+        buffer: vec![],
+    };
+    encode(make_response_with_session(
+        ResponseContent::SessionSetup(content),
+        2,
+        Status::Success,
+        session_id,
+    ))
+}
+
+/// Variant of [`negotiate_response_windows_dc`] modeling a permissive
+/// server: signing is *enabled* but **not required**. Identical
+/// dialect / capability shape otherwise. Used by the anonymous-session
+/// test where the client must still send + sign per spec, but the
+/// server policy doesn't force it.
+pub fn negotiate_response_signing_optional() -> Bytes {
+    let content = NegotiateResponse {
+        security_mode: NegotiateSecurityMode::new().with_signing_enabled(true),
+        // signing_required omitted (defaults false) — the difference
+        // from `negotiate_response_windows_dc` is this single bit.
+        dialect_revision: NegotiateDialect::Smb0311,
+        server_guid: smb_dtyp::Guid::from([
+            0xde, 0xad, 0xbe, 0xef, 0x00, 0x00, 0x40, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x01,
+        ]),
+        capabilities: GlobalCapabilities::new()
+            .with_dfs(true)
+            .with_leasing(true)
+            .with_large_mtu(true)
+            .with_directory_leasing(true),
+        max_transact_size: 8 * 1024 * 1024,
+        max_read_size: 8 * 1024 * 1024,
+        max_write_size: 8 * 1024 * 1024,
+        system_time: smb_dtyp::binrw_util::file_time::FileTime::default(),
+        server_start_time: smb_dtyp::binrw_util::file_time::FileTime::default(),
+        buffer: vec![0x60, 0x18, 0x06, 0x06, 0x2b, 0x06, 0x01, 0x05, 0x05, 0x02],
+        negotiate_context_list: Some(vec![
+            negotiate_ctx_preauth(),
+            negotiate_ctx_encryption(),
+            negotiate_ctx_signing(),
+        ]),
+    };
+    encode(make_response(
+        ResponseContent::Negotiate(content),
+        0,
+        Status::Success,
+    ))
+}
+
 fn make_response(content: ResponseContent, message_id: u64, status: Status) -> PlainResponse {
     let mut resp = PlainResponse::new(content);
     // Only patch the fields that differ from the defaulted header

--- a/crates/smb/tests/conformance_anonymous.rs
+++ b/crates/smb/tests/conformance_anonymous.rs
@@ -1,0 +1,84 @@
+//! Conformance test: anonymous session + SMB 3.1.1 + signing optional.
+//!
+//! Covers the spec branch that lets the driver accept an **unsigned**
+//! final SessionSetup Response when the resulting session is
+//! anonymous (`session_flags.is_null_session = true`). MS-SMB2
+//! §3.2.5.3.1: no SessionKey is derived for an anonymous bind, so the
+//! server has no signing material; the client must *not* fall through
+//! to `SetupError::UnsignedFinalResponse` in this case.
+//!
+//! This locks the negation of the Windows-DC regression — the same
+//! "unsigned final response" wire pattern that's an error there is
+//! the *expected* outcome here. The driver's `is_guest_or_null_session`
+//! short-circuit must keep working.
+
+#[path = "conformance/mod.rs"]
+mod conformance;
+
+use conformance::transcripts::{
+    negotiate_response_signing_optional, session_setup_response_final_anonymous,
+    session_setup_response_intermediate,
+};
+use conformance::{MockGss, MockTransport, ScriptedGssStep};
+use smb::{Connection, ConnectionConfig};
+use smb_dtyp::Guid;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn anonymous_session_accepts_unsigned_final_response() {
+    const SESSION_ID: u64 = 0x0000_1234_5678_9abc;
+
+    let (transport, control) = MockTransport::new();
+    control.push_server_frame(negotiate_response_signing_optional());
+    control.push_server_frame(session_setup_response_intermediate(SESSION_ID));
+    control.push_server_frame(session_setup_response_final_anonymous(SESSION_ID));
+
+    let mut config = ConnectionConfig::default();
+    config.smb2_only_negotiate = true;
+    config.timeout = Some(std::time::Duration::from_secs(5));
+    // Anonymous sessions must be permitted by config or the driver
+    // rejects the success reply outright (state.rs::ready check).
+    config.allow_unsigned_guest_access = true;
+    let conn = Connection::from_transport(transport, "samba-anon.test", Guid::generate(), config)
+        .await
+        .expect("Negotiate must succeed");
+
+    // Scripted GSS mirrors the windows-dc test but the resulting
+    // session is flagged anonymous by the server, so the final
+    // response — unsigned — is accepted on the spec's anonymous path.
+    let gss = MockGss::new(
+        "anonymous",
+        None,
+        [0x00; 16],
+        vec![
+            ScriptedGssStep {
+                client_token: b"<type1>".to_vec(),
+                completes_auth: false,
+            },
+            ScriptedGssStep {
+                client_token: b"<type3>".to_vec(),
+                completes_auth: true,
+            },
+        ],
+    );
+
+    let result = conn.authenticate_with_gss(gss).await;
+
+    // Drop the connection now to make any future drop bug surface in
+    // this test rather than in the windows-dc one.
+    drop(conn);
+
+    // Driver must accept the unsigned response because the session is
+    // anonymous. If it instead returned `SetupError::UnsignedFinalResponse`,
+    // the windows-dc regression got over-broad.
+    let session = result.expect(
+        "anonymous session: unsigned final SessionSetup Response is spec-valid; \
+         driver must not return SetupError::UnsignedFinalResponse here",
+    );
+
+    // session_id should match what the mock server advertised.
+    assert_eq!(session.session_id(), SESSION_ID);
+
+    // Don't hold the session into Drop: same MockTransport-deadlock
+    // concern as the windows-dc test.
+    std::mem::forget(session);
+}


### PR DESCRIPTION
## Summary

Re-targets the PR #5 work onto \`main\` after the GitHub stacked-PR plumbing left it pointing at the now-merged base branch \`refactor/session-setup-bugfix\`. No new code — this PR contains exactly the three commits that were already reviewed and merged in #5; opening this PR is the only way to actually land them on \`main\`.

## Commits

1. \`8bf8ce1\` — \`refactor(transformer): own connection preauth integrity hash\` (S4)
2. \`fd48647\` — \`test(conformance): anonymous SessionSetup spec-branch regression\` (S9)
3. \`71be672\` — \`refactor(msg_handler): replace setup_phase_signing_key with Protection enum\` (S5-T1)

See PR #5 for the full review history and rationale.

## Test plan

- [x] \`cargo check -p smb\` (default features) — 0 warnings, 0 errors
- [x] \`cargo check -p smb --features test-support\` — 0 warnings, 0 errors
- [x] \`cargo test -p smb --lib\` — 16 / 16 pass
- [x] \`cargo test -p smb --features test-support --lib\` — 16 / 16 pass
- [x] \`cargo test --test conformance_smoke\` — 3 / 3 pass
- [x] \`cargo test --test conformance_windows_dc_ntlm\` — 1 / 1 pass
- [x] \`cargo test --test conformance_anonymous\` — 1 / 1 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)