### PR TITLE
refactor(transformer): dispatch on Protection enum, not legacy bool fields

### DIFF
--- a/crates/smb/src/connection/transformer.rs
+++ b/crates/smb/src/connection/transformer.rs
@@ -448,8 +448,20 @@ impl Transformer {
 
     /// Transforms an outgoing message to a raw SMB message.
     pub async fn transform_outgoing(&self, mut msg: OutgoingMessage) -> crate::Result<IoVec> {
-        let should_encrypt = msg.encrypt;
-        let should_sign = msg.message.header.flags.signed();
+        // Single source of truth for what to do with this message: the
+        // sealed `Protection` enum. Callers that haven't been migrated
+        // off the legacy `encrypt: bool` / `flags.signed()` hint fields
+        // fall through to a compatibility branch that mirrors the old
+        // behaviour — most of those callers (Negotiate Request) want
+        // no protection at all.
+        let (should_sign, should_encrypt) = match &msg.security {
+            Some(Protection::None) => (false, false),
+            Some(Protection::SignWithChannel) | Some(Protection::SnapshotKdfSign { .. }) => {
+                (true, false)
+            }
+            Some(Protection::Encrypt) => (false, true),
+            None => (msg.message.header.flags.signed(), msg.encrypt),
+        };
         let session_id = msg.message.header.session_id;
 
         let mut outgoing_data = IoVec::default();

--- a/crates/smb/src/msg_handler.rs
+++ b/crates/smb/src/msg_handler.rs
@@ -56,11 +56,22 @@ pub struct OutgoingMessage {
 
 /// Explicit security treatment for an [`OutgoingMessage`].
 ///
-/// Sealed at construction by the caller, so the transformer doesn't
-/// need to re-derive the choice from mutable session state at send
-/// time. See [`OutgoingMessage::security`] for the rationale.
+/// Sealed at construction by the caller (or, for legacy paths,
+/// inferred by `ChannelMessageHandler::sendo` from session state and
+/// stamped into the message before it leaves the channel layer), so
+/// the transformer can dispatch purely on this enum without
+/// inspecting other mutable state.
 #[derive(Debug, Clone)]
 pub enum Protection {
+    /// No transport-layer protection. Used for Negotiate and the
+    /// pre-channel SessionSetup exchanges where signing keys don't
+    /// yet exist, plus anonymous / guest sessions where signing is
+    /// allowed to be skipped.
+    None,
+    /// Sign this request with the channel's cached signer (the
+    /// production wire-secured path). Looked up from
+    /// `session_state.channel.signer` at sign time.
+    SignWithChannel,
     /// Sign this request with a one-shot key derived from the given
     /// GSS-supplied SessionKey and the transformer's currently
     /// finalized preauth hash (after the request's own plain bytes
@@ -69,6 +80,11 @@ pub enum Protection {
     SnapshotKdfSign {
         session_key: crate::crypto::KeyToDerive,
     },
+    /// Encrypt this request with the session's cached encryptor.
+    /// Mutually exclusive with the signing variants per MS-SMB2
+    /// §3.1.4.1 (a transport-encrypted message carries its
+    /// confidentiality MAC, no separate signature).
+    Encrypt,
 }
 
 impl OutgoingMessage {

--- a/crates/smb/src/session/channel.rs
+++ b/crates/smb/src/session/channel.rs
@@ -1,3 +1,5 @@
+use crate::msg_handler::Protection;
+
 use super::*;
 
 pub(crate) type ChannelUpstream = HandlerReference<ConnectionMessageHandler>;
@@ -235,34 +237,58 @@ impl ChannelMessageHandler {
 #[maybe_async(AFIT)]
 impl MessageHandler for ChannelMessageHandler {
     async fn sendo(&self, mut msg: OutgoingMessage) -> crate::Result<SendMessageResult> {
-        {
+        // If the caller already sealed a [`Protection`] decision (e.g.
+        // the session-setup driver attaching `SnapshotKdfSign`), honor
+        // it as-is. Otherwise translate the session state into a
+        // matching `Protection` variant here, once, so the transformer
+        // doesn't have to re-derive it from `msg.encrypt` /
+        // `header.flags.signed` later.
+        if msg.security.is_none() {
             let session = self.session_state.read().await?;
             let session = session.session.read().await?;
             if session.is_invalid() {
                 return Err(Error::InvalidState("Session is invalid".to_string()));
             }
 
-            // It is possible for a lower level to request encryption.
+            // It is possible for a lower-level / builder caller to
+            // pre-request encryption via `with_encrypt(true)`; convert
+            // it to the matching Protection variant. The session must
+            // be ready to actually serve an encryptor.
             if msg.encrypt {
-                // Session must be ready to encrypt messages.
                 if !session.is_ready() {
                     return Err(Error::InvalidState(
                         "Session is not ready, cannot encrypt message".to_string(),
                     ));
                 }
-            }
-            // Otherwise, we should check the session's configuration.
-            else if session.is_ready() || session.is_setting_up() {
-                // Encrypt if configured for the session,
+                msg.security = Some(Protection::Encrypt);
+            } else if session.is_ready() || session.is_setting_up() {
                 if session.is_ready() && session.should_encrypt()? {
-                    msg.encrypt = true;
+                    msg.security = Some(Protection::Encrypt);
+                } else if !session.allow_unsigned()? {
+                    msg.security = Some(Protection::SignWithChannel);
+                } else {
+                    msg.security = Some(Protection::None);
                 }
-                // Sign
-                else if !session.allow_unsigned()? {
-                    msg.message.header.flags.set_signed(true);
-                }
+            } else {
+                msg.security = Some(Protection::None);
             }
         }
+
+        // Mirror the chosen Protection onto the legacy hint fields so
+        // compound paths and worker logging that still read those
+        // fields see consistent state. Removing these reads is
+        // deferred to S7's transformer rework.
+        match &msg.security {
+            Some(Protection::SignWithChannel) | Some(Protection::SnapshotKdfSign { .. }) => {
+                msg.message.header.flags.set_signed(true);
+                msg.encrypt = false;
+            }
+            Some(Protection::Encrypt) => {
+                msg.encrypt = true;
+            }
+            Some(Protection::None) | None => {}
+        }
+
         msg.message.header.session_id = self.session_id;
         self.upstream.sendo(msg).await
     }


### PR DESCRIPTION
## Summary

Wires the \`Protection\` enum (added in #5 / S5-T1) through the actual
sign/encrypt decision so the transformer dispatches on a single
sealed field instead of two separate hint bools that could disagree.
This closes the double-signal class of bug that produced the
Windows-DC silent-drop regression.

## Why

Before this PR the transformer made two independent decisions:

| What | Read from |
|------|-----------|
| Encrypt? | \`msg.encrypt: bool\` |
| Sign?    | \`msg.message.header.flags.signed(): bool\` |

Both were stamped either by \`ChannelMessageHandler::sendo\` (based on
session state) or by the caller via the \`with_encrypt(true)\` builder.
A code path that set one without the other — or that read session
state inconsistently — would put the transformer in a hybrid state.
The Windows-DC regression was an instance of that family: \`sendo\`
fell through its inference branches on a session in \`Initial\` state,
leaving both bools at their default \`false\`, while the
session-setup driver was busy installing the channel signer *after*
the transformer had already sent the request unsigned.

## Changes

* \`Protection\` enum gains three new variants: \`None\`,
  \`SignWithChannel\`, \`Encrypt\`. \`SnapshotKdfSign\` is unchanged.
* \`ChannelMessageHandler::sendo\` converts its existing
  session-state-driven inference into a \`Protection\` variant on the
  outgoing message, instead of poking \`msg.encrypt\` /
  \`header.flags.set_signed\` directly. Pre-sealed messages
  (\`security = Some(...)\`) pass through unchanged.
* \`Transformer::transform_outgoing\` derives \`should_sign\` /
  \`should_encrypt\` from \`msg.security\`, with a documented legacy
  fallback that reads the old bool fields when \`security\` is \`None\`
  (Negotiate Request and the compound path still rely on those).

## Behaviour

- Production paths (\`tree_connect\`, \`create\`, \`read\`, \`write\`, ...,
  ~100 call sites): unchanged. They route through
  \`ChannelMessageHandler::sendo\`, which now stamps \`Protection\`
  before forwarding. No caller-side change required.
- Session-setup driver: already on \`Protection::SnapshotKdfSign\`
  since #5.
- Builder API (\`with_encrypt(true)\`): preserved. \`sendo\` reads
  \`msg.encrypt\`, validates the session can encrypt, and re-emits as
  \`Protection::Encrypt\`.

## Test plan

- [x] \`cargo check -p smb\` (default features) — 0 warnings, 0 errors
- [x] \`cargo check -p smb --features test-support\` — 0 warnings, 0 errors
- [x] \`cargo test -p smb --lib\` — 16 / 16 pass
- [x] \`cargo test -p smb --features test-support --lib\` — 16 / 16 pass
- [x] \`cargo test --test conformance_smoke\` — 3 / 3 pass
- [x] \`cargo test --test conformance_windows_dc_ntlm\` — 1 / 1 pass (regression still locked)
- [x] \`cargo test --test conformance_anonymous\` — 1 / 1 pass (anonymous spec branch still locked)

Total: 21 / 21.

## Out of scope

- The legacy \`msg.encrypt\` / \`header.flags.signed()\` fallback is kept
  in \`transform_outgoing\` for compatibility with
  \`Connection::_negotiate\` and the compound path
  (\`transform_outgoing_compound\` still reads
  \`header.flags.signed()\`). Migrating those to set \`Protection\`
  explicitly is a follow-up.
- \`OutgoingMessage::encrypt: bool\` and the \`with_encrypt(true)\`
  builder remain for public-API compatibility. They route through
  \`sendo\`'s conversion logic, not the transformer directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)