### PR TITLE
test(conformance): SMB 3.0.2 dialect downgrade regression

### DIFF
--- a/crates/smb/tests/conformance/transcripts.rs
+++ b/crates/smb/tests/conformance/transcripts.rs
@@ -77,6 +77,51 @@ pub fn negotiate_response_windows_dc() -> Bytes {
     encode(make_response(ResponseContent::Negotiate(content), 0, Status::Success))
 }
 
+/// Variant of [`negotiate_response_windows_dc`] modeling a server
+/// that negotiates **SMB 3.0.2** instead of 3.1.1. Materially:
+///
+/// - No PreauthIntegrityCapabilities / EncryptionCapabilities /
+///   SigningCapabilities — those negotiate contexts are 3.1.1-only.
+/// - `negotiate_context_list = None` (3.0.2 doesn't carry one).
+/// - The connection-level preauth hash stays at
+///   `PreauthHashState::Unsupported`, which exercises the
+///   transformer's noop-ingest path that the post-S4 refactor
+///   introduced but no other test covers.
+/// - Channel signing key still gets derived (it's the
+///   `SmbSign\x00` static-context branch in
+///   `SessionAlgosFactory::smb3xx_make_signer`), so the final
+///   SessionSetup Request must still be signed per MS-SMB2 §3.3.5.5.3.
+pub fn negotiate_response_smb302_signing_required() -> Bytes {
+    let content = NegotiateResponse {
+        security_mode: NegotiateSecurityMode::new()
+            .with_signing_enabled(true)
+            .with_signing_required(true),
+        dialect_revision: NegotiateDialect::Smb0302,
+        server_guid: Guid::from([
+            0x30, 0x02, 0x30, 0x02, 0x00, 0x00, 0x40, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x02,
+        ]),
+        capabilities: GlobalCapabilities::new()
+            .with_dfs(true)
+            .with_leasing(true)
+            .with_large_mtu(true)
+            .with_directory_leasing(true),
+        max_transact_size: 8 * 1024 * 1024,
+        max_read_size: 8 * 1024 * 1024,
+        max_write_size: 8 * 1024 * 1024,
+        system_time: FileTime::default(),
+        server_start_time: FileTime::default(),
+        buffer: vec![0x60, 0x18, 0x06, 0x06, 0x2b, 0x06, 0x01, 0x05, 0x05, 0x02],
+        // SMB 3.0.2 negotiates without a context list.
+        negotiate_context_list: None,
+    };
+    encode(make_response(
+        ResponseContent::Negotiate(content),
+        0,
+        Status::Success,
+    ))
+}
+
 fn negotiate_ctx_preauth() -> NegotiateContext {
     PreauthIntegrityCapabilities {
         hash_algorithms: vec![HashAlgorithm::Sha512],

--- a/crates/smb/tests/conformance_smb302.rs
+++ b/crates/smb/tests/conformance_smb302.rs
@@ -1,0 +1,95 @@
+//! Conformance test: SMB 3.0.2 + `signing_required = true`.
+//!
+//! Locks the "dialect doesn't support preauth integrity" branch of
+//! the transformer's preauth-hash plumbing. SMB 3.0.2 negotiates
+//! without a Negotiate context list, so:
+//!
+//! - `PreauthHashState` stays `Unsupported` on the connection,
+//! - `Transformer::transform_outgoing` / `transform_incoming`'s
+//!   auto-ingest is a noop (the `Unsupported.next(_)` branch),
+//! - `snapshot_preauth_finalized` returns `Ok(None)`,
+//! - `ChannelInfo::new` derives the SigningKey using the static
+//!   `SmbSign\0` context (the `preauth_hash = None` branch in
+//!   `SessionAlgosFactory::smb3xx_make_signer`).
+//!
+//! But MS-SMB2 §3.3.5.5.3's "non-anonymous SMB 3.x SessionSetup
+//! final Request must be signed" rule applies independently of the
+//! preauth-integrity feature. The driver must still produce a
+//! signed final Request — this test asserts that exactly.
+
+#[path = "conformance/mod.rs"]
+mod conformance;
+
+use bytes::Bytes;
+use conformance::transcripts::{
+    negotiate_response_smb302_signing_required, session_setup_response_final,
+    session_setup_response_intermediate,
+};
+use conformance::{
+    MockGss, MockTransport, ScriptedGssStep, assert_signed_final_session_setup,
+};
+use smb::{Connection, ConnectionConfig};
+use smb_dtyp::Guid;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn smb302_signing_required_signs_final_session_setup() {
+    const SESSION_ID: u64 = 0x0000_0302_8000_000A;
+
+    let (transport, control) = MockTransport::new();
+    control.push_server_frame(negotiate_response_smb302_signing_required());
+    control.push_server_frame(session_setup_response_intermediate(SESSION_ID));
+    control.push_server_frame(session_setup_response_final(SESSION_ID));
+
+    let mut config = ConnectionConfig::default();
+    config.smb2_only_negotiate = true;
+    config.timeout = Some(std::time::Duration::from_secs(5));
+    let conn = Connection::from_transport(transport, "smb302.test", Guid::generate(), config)
+        .await
+        .expect("Negotiate must succeed against SMB 3.0.2 mock server");
+
+    let gss = MockGss::new(
+        "bob",
+        Some("EXAMPLE"),
+        [0x22; 16],
+        vec![
+            ScriptedGssStep {
+                client_token: b"<scripted-ntlm-type1-smb302>".to_vec(),
+                completes_auth: false,
+            },
+            ScriptedGssStep {
+                client_token: b"<scripted-ntlm-type3-smb302>".to_vec(),
+                completes_auth: true,
+            },
+        ],
+    );
+
+    // The mock server's final SessionSetup Response is unsigned, so
+    // the driver rejects it with SetupError::UnsignedFinalResponse —
+    // same flow as the windows-dc test. We capture but don't fail on
+    // this; the real assertion is on the client-emitted frames.
+    let auth_result = conn.authenticate_with_gss(gss).await;
+    match &auth_result {
+        Err(smb::Error::Setup(smb::error::SetupError::UnsignedFinalResponse)) => {}
+        Err(other) => panic!(
+            "expected SetupError::UnsignedFinalResponse against the mock unsigned reply, got: {other}"
+        ),
+        Ok(_) => panic!(
+            "authenticate_with_gss unexpectedly succeeded — the mock server's final response is unsigned"
+        ),
+    }
+
+    let frames = control.captured_client_frames();
+    drop(conn);
+
+    assert!(
+        frames.len() >= 3,
+        "expected at least 3 client frames (Negotiate + 2× SessionSetup), got {}",
+        frames.len()
+    );
+
+    // Frame #2 is the final SessionSetup Request (NTLM Type3). Per
+    // MS-SMB2 §3.3.5.5.3 it must be signed even though SMB 3.0.2
+    // doesn't fold the request into a preauth hash.
+    let req2: &Bytes = &frames[2];
+    assert_signed_final_session_setup(req2, 2);
+}


### PR DESCRIPTION
## Summary

Adds a deterministic transcript test pinning the SMB 3.0.2
\"dialect doesn't support preauth integrity\" branch of the
transformer's preauth-hash plumbing. That branch is exercised by
every SMB 3.0 / 3.0.2 connection in production but had **no test
coverage** before this PR — the post-S4 transformer refactor
introduced auto-ingest logic that has to no-op cleanly on
\`PreauthHashState::Unsupported\`, and there was no regression net
under that path.

## What's pinned

Specifically the four code paths that activate only when
\`PreauthHashState::Unsupported\`:

| Path | Branch |
|------|--------|
| \`Transformer::transform_outgoing\` / \`transform_incoming\` ingest | \`Unsupported.next(_)\` returns \`Unsupported\` unchanged |
| \`Transformer::snapshot_preauth_finalized\` | \`Ok(None)\` |
| \`ChannelInfo::new\` | \`preauth_hash = None\` branch in \`SessionAlgosFactory::smb3xx_make_signer\` |
| MS-SMB2 §3.3.5.5.3 | Non-anonymous final SessionSetup still signed without preauth integrity |

## Changes

* \`transcripts::negotiate_response_smb302_signing_required\` — same
  shape as \`negotiate_response_windows_dc\` minus the 3.1.1-only
  Negotiate context list, with \`dialect_revision = Smb0302\` and
  \`negotiate_context_list = None\`.
* \`tests/conformance_smb302.rs\` — drives Negotiate + 2-round NTLM
  SessionSetup against the SMB 3.0.2 mock and asserts:
  - the driver returns \`SetupError::UnsignedFinalResponse\` against
    the (deliberately) unsigned mock reply,
  - the *client*'s final SessionSetup Request still carries
    \`flags.signed = true\` plus a non-zero signature.

## Test plan

- [x] \`cargo check -p smb --features test-support\` — 0 warnings, 0 errors
- [x] \`cargo test -p smb --features test-support --test conformance_smb302\` — 1 / 1 pass
- [x] Full regression suite stays green:
  - \`--lib\` — 16 / 16
  - \`conformance_smoke\` — 3 / 3
  - \`conformance_windows_dc_ntlm\` — 1 / 1
  - \`conformance_anonymous\` — 1 / 1
  - \`conformance_smb302\` (new) — 1 / 1
  - **Total: 22 / 22**

## Where this sits in the conformance matrix

| Test | Dialect | signing_required | Anonymous | Preauth integrity |
|------|---------|------------------|-----------|-------------------|
| \`conformance_windows_dc_ntlm\` | 3.1.1 | yes | no | yes |
| \`conformance_anonymous\` | 3.1.1 | no | yes | yes |
| **\`conformance_smb302\`** (this PR) | **3.0.2** | **yes** | **no** | **no** |

Remaining matrix slots (samba-signing-required, azure-files-encryption,
netapp-ontap-90) tracked as S9 batch 3 follow-ups — low-priority
incremental work, no protocol property currently uncovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)