### PR TITLE
test(conformance): fix flaky MockTransport send/recv race

### DIFF
--- a/crates/smb/tests/conformance/mock_transport.rs
+++ b/crates/smb/tests/conformance/mock_transport.rs
@@ -55,6 +55,19 @@ struct TranscriptInner {
     /// shutdown that interrupts the client *before* it gets to send
     /// the next request.
     frame_pushed: Notify,
+    /// Notified by `MockWrite::feed` each time a complete client frame
+    /// is captured. Lets tests await "the production driver has written
+    /// at least N frames" without polling, closing the race between
+    /// `worker.send()` (which returns as soon as the IoVec is queued on
+    /// the send channel, *before* the worker task issues `send_raw`)
+    /// and the test asserting on `captured_client_frames()`.
+    ///
+    /// In a real wire setup the response cannot arrive before the
+    /// request goes out, so the race is invisible. MockTransport
+    /// delivers pre-queued responses immediately on read, decoupling
+    /// the two halves and exposing the production-side fire-and-forget
+    /// send semantics. This Notify lets the test synchronise explicitly.
+    frame_captured: Notify,
 }
 
 impl TranscriptControl {
@@ -103,6 +116,41 @@ impl TranscriptControl {
             .expect("transcript mutex poisoned")
             .len()
     }
+
+    /// Wait until at least `min_frames` client frames have been
+    /// captured, or `timeout` elapses. Returns `true` if the threshold
+    /// was reached, `false` on timeout.
+    ///
+    /// Closes the production-side fire-and-forget send race: the
+    /// driver's `worker.send()` returns when the message is queued on
+    /// the send channel, *not* when `send_raw` actually completes — so
+    /// the test must wait for the side effect explicitly before
+    /// reading captured frames. See [`TranscriptInner::frame_captured`]
+    /// for the longer explanation.
+    pub async fn wait_for_captured_frames(
+        &self,
+        min_frames: usize,
+        timeout: std::time::Duration,
+    ) -> bool {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            // Acquire the notification before the count check, per
+            // tokio's documented race-free pattern.
+            let notified = self.inner.frame_captured.notified();
+            tokio::pin!(notified);
+
+            if self.client_frame_count() >= min_frames {
+                return true;
+            }
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return false;
+            }
+            if tokio::time::timeout(remaining, notified).await.is_err() {
+                return self.client_frame_count() >= min_frames;
+            }
+        }
+    }
 }
 
 /// Full-duplex mock. Implements [`SmbTransport`] so it can be passed to
@@ -141,9 +189,7 @@ impl SmbTransport for MockTransport {
         445
     }
 
-    fn split(
-        self: Box<Self>,
-    ) -> Result<(Box<dyn SmbTransportRead>, Box<dyn SmbTransportWrite>)> {
+    fn split(self: Box<Self>) -> Result<(Box<dyn SmbTransportRead>, Box<dyn SmbTransportWrite>)> {
         let me = *self;
         Ok((Box::new(me.read), Box::new(me.write)))
     }
@@ -306,14 +352,18 @@ impl MockWrite {
                     self.body_accumulator.extend_from_slice(&buf[..take]);
                     let new_remaining = remaining - take;
                     if new_remaining == 0 {
-                        let frame =
-                            Bytes::from(std::mem::take(&mut self.body_accumulator));
+                        let frame = Bytes::from(std::mem::take(&mut self.body_accumulator));
                         self.control
                             .inner
                             .client_frames
                             .lock()
                             .expect("transcript mutex poisoned")
                             .push(frame);
+                        // Wake any test that's awaiting on
+                        // `wait_for_captured_frames` (closes the race
+                        // against `worker.send()` returning before the
+                        // worker task actually issues `send_raw`).
+                        self.control.inner.frame_captured.notify_waiters();
                         self.phase = SendPhase::AwaitingHeader;
                     } else {
                         self.phase = SendPhase::AwaitingBody {

--- a/crates/smb/tests/conformance_smb302.rs
+++ b/crates/smb/tests/conformance_smb302.rs
@@ -25,9 +25,7 @@ use conformance::transcripts::{
     negotiate_response_smb302_signing_required, session_setup_response_final,
     session_setup_response_intermediate,
 };
-use conformance::{
-    MockGss, MockTransport, ScriptedGssStep, assert_signed_final_session_setup,
-};
+use conformance::{MockGss, MockTransport, ScriptedGssStep, assert_signed_final_session_setup};
 use smb::{Connection, ConnectionConfig};
 use smb_dtyp::Guid;
 
@@ -78,6 +76,17 @@ async fn smb302_signing_required_signs_final_session_setup() {
         ),
     }
 
+    // worker.send() returns once the message is queued on the worker's
+    // send channel, before the worker task issues send_raw — wait for
+    // the wire-side effect explicitly to avoid races with the
+    // pre-queued mock responses. See `TranscriptControl::wait_for_captured_frames`.
+    assert!(
+        control
+            .wait_for_captured_frames(3, std::time::Duration::from_secs(2))
+            .await,
+        "timed out waiting for 3 client frames; got {}",
+        control.client_frame_count()
+    );
     let frames = control.captured_client_frames();
     drop(conn);
 

--- a/crates/smb/tests/conformance_windows_dc_ntlm.rs
+++ b/crates/smb/tests/conformance_windows_dc_ntlm.rs
@@ -34,9 +34,7 @@ use conformance::transcripts::{
     negotiate_response_windows_dc, session_setup_response_final,
     session_setup_response_intermediate,
 };
-use conformance::{
-    MockGss, MockTransport, ScriptedGssStep, assert_signed_final_session_setup,
-};
+use conformance::{MockGss, MockTransport, ScriptedGssStep, assert_signed_final_session_setup};
 use smb::{Connection, ConnectionConfig};
 use smb_dtyp::Guid;
 
@@ -100,6 +98,21 @@ async fn windows_dc_signing_required_signs_final_session_setup() {
     }
 
     // -- 4. Inspect what the client put on the wire. --
+    //
+    // The driver's `worker.send()` returns when the message is queued on
+    // the worker's send channel, not when `send_raw` actually completes.
+    // On a real wire the response cannot arrive before the request goes
+    // out, so the test is naturally serialised; with MockTransport's
+    // pre-queued responses the two halves are decoupled, so we must
+    // explicitly wait for the captured-frames side effect before
+    // asserting on it. See `TranscriptControl::wait_for_captured_frames`.
+    assert!(
+        control
+            .wait_for_captured_frames(3, std::time::Duration::from_secs(2))
+            .await,
+        "timed out waiting for 3 client frames; got {}",
+        control.client_frame_count()
+    );
     let frames = control.captured_client_frames();
     drop(conn); // explicit: surfaces any future drop bug instead of leaking it
     assert!(


### PR DESCRIPTION
## Summary

Closes the production-side fire-and-forget send race that lets
`conformance_windows_dc_ntlm` and `conformance_smb302` intermittently
fail with `'expected at least 3 client frames, got 2'` when run under
load alongside the rest of the conformance binary set.

## Root cause

`ParallelWorker::send()` returns once the message is queued on the
worker's send channel ([parallel/base.rs:343](https://github.com/JayTsu-sh/smb-rs/blob/b86a8bf/crates/smb/src/connection/worker/parallel/base.rs#L343)),
**not** when the worker task actually issues `send_raw` on the
transport. On a real network this is invisible because the server's
response cannot arrive before the request goes out — the wire enforces
ordering.

MockTransport decouples the two halves: pre-queued server frames are
delivered immediately on each `MockRead::receive_exact` regardless of
whether the matching client request has actually been written through
`MockWrite`. So this sequence is possible:

1. driver: `worker.send(SessionSetup #2)` → queued, returns
2. driver: `worker.receive(msg_id=2)` → pops pre-queued
   `UnsignedFinalResponse`
3. driver: raises `SetupError::UnsignedFinalResponse`
4. test: `control.captured_client_frames()` → Type3 frame not yet
   captured by MockWrite!

Visible symptom: `frames.len() >= 3` panics with `len == 2` (Negotiate
+ Type1 captured; Type3 still in flight).

## Fix

- `TranscriptControl::wait_for_captured_frames(min_frames, timeout)`
  awaits a per-capture `Notify`
- `MockWrite::feed` calls `notify_waiters()` after each completed frame
- `conformance_windows_dc_ntlm` and `conformance_smb302` now wait on
  it before reading frames

`Notify` is acquired before the count check (tokio's documented
race-free pattern), so a late-arriving send still wakes us up.

The anonymous test doesn't read `captured_client_frames`, so it
doesn't need the fix.

## Verification

- `cargo check -p smb --features test-support --all-targets`: clean
- 5× running all 4 conformance tests as one cargo invocation:
  smoke (3) + windows_dc (1) + anonymous (1) + smb302 (1) = **30/30 pass**

Pre-S7 sanity-check: trust this test suite as the regression net for
the upcoming ConnectionActor rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)